### PR TITLE
fix: resolve all 53 GitHub issues across code, docs, and build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -848,8 +848,7 @@ Transitive dependency vulnerabilities in `devDependencies` are addressed via `pn
 
 | Channel | Use for |
 | --- | --- |
-| [GitHub Issues](https://github.com/CyberCraftBD/power-seo/issues) | Bug reports, feature requests, questions |
-| [GitHub Discussions](https://github.com/CyberCraftBD/power-seo/discussions) | General questions, ideas, show & tell |
+| [GitHub Issues](https://github.com/CyberCraftBD/power-seo/issues) | Bug reports, feature requests, general questions, ideas |
 | [info@ccbd.dev](mailto:info@ccbd.dev) | Security issues, partnership inquiries |
 
 If you're unsure whether a change is appropriate for a PR, open an issue first and describe what you want to do. It's better to discuss upfront than to submit a large PR that needs to be redesigned.

--- a/apps/docs/src/content/docs/packages/core.mdx
+++ b/apps/docs/src/content/docs/packages/core.mdx
@@ -1,97 +1,528 @@
 ---
 title: "@power-seo/core"
-description: "Core utilities, types, constants, and meta tag builders for the @power-seo monorepo."
+description: "Framework-agnostic SEO utilities, types, and engines — the shared foundation of the entire @power-seo ecosystem, usable as a standalone TypeScript library that works anywhere."
 ---
 
-## Install
+# @power-seo/core
+
+![core banner](../../image/core/banner.svg)
+
+Framework-agnostic SEO utilities, types, and engines — the shared foundation of the entire @power-seo ecosystem, usable as a standalone TypeScript library that works anywhere.
+
+[![npm version](https://img.shields.io/npm/v/@power-seo/core)](https://www.npmjs.com/package/@power-seo/core)
+[![npm downloads](https://img.shields.io/npm/dm/@power-seo/core)](https://www.npmjs.com/package/@power-seo/core)
+[![Socket](https://socket.dev/api/badge/npm/package/@power-seo/core)](https://socket.dev/npm/package/@power-seo/core)
+[![npm provenance](https://img.shields.io/badge/npm-provenance-enabled-blue)](https://github.com/CyberCraftBD/power-seo/actions)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
+[![tree-shakeable](https://img.shields.io/badge/tree--shakeable-yes-brightgreen)](https://bundlephobia.com/package/@power-seo/core)
+
+`@power-seo/core` is the foundational library shared by all 17 `@power-seo` packages. It delivers pixel-accurate meta validators, structured meta and link tag builders, URL normalization, keyword density analysis, text statistics, Open Graph and Twitter Card builders, robots directive generation, title template engines, and a token-bucket rate limiter — all in a single zero-dependency TypeScript package. Think of it as combining `next-seo`, `seo-utils`, `keyword-density`, `url-normalize`, and `text-statistics` into one unified, tree-shakeable library that runs in Next.js, Remix, Vite, vanilla Node.js, Cloudflare Workers, and Vercel Edge. All 9 utility modules are fully configurable and independently importable.
+
+> **Zero runtime dependencies** — installs clean with nothing else to pull in.
+
+---
+
+## Why @power-seo/core?
+
+| | Without | With |
+|---|---|---|
+| Meta tag building | ❌ Hand-written HTML strings | ✅ Type-safe `buildMetaTags()` with OG + Twitter |
+| Title validation | ❌ Character count only | ✅ Pixel-accurate SERP width via `validateTitle()` |
+| Keyword density | ❌ Manual regex counting | ✅ `calculateKeywordDensity()` with density % |
+| URL canonicalization | ❌ String manipulation | ✅ `resolveCanonical()` with full normalization |
+| Text statistics | ❌ Multiple separate packages | ✅ `getTextStatistics()` — words, sentences, syllables |
+| Robots directives | ❌ Concatenated strings | ✅ Type-safe `buildRobotsContent()` builder |
+| Title templates | ❌ Manual string interpolation | ✅ `createTitleTemplate()` with site-wide defaults |
+| Rate limiting | ❌ No built-in utility | ✅ Token bucket `createTokenBucket()` for API calls |
+| TypeScript types | ❌ Duplicated across packages | ✅ 25+ shared interfaces for the full ecosystem |
+
+![SEO Utilities Dashboard](../../image/core/utilities-dashboard.svg)
+
+---
+
+## Features
+
+- **Meta tag builder** — `buildMetaTags()` generates typed arrays of meta tags from a structured `SEOConfig`
+- **Open Graph builder** — `buildOpenGraphTags()` with full support for article, profile, book, video, and music OG types
+- **Twitter Card builder** — `buildTwitterTags()` for summary, large image, player, and app card types
+- **Hreflang builder** — `buildHreflangTags()` generates `<link rel="alternate">` tags for multi-language pages
+- **Title template engine** — `applyTitleTemplate()` and `createTitleTemplate()` with `%variable%` substitution and separator cleanup
+- **Pixel-accurate meta validators** — `validateTitle()` and `validateMetaDescription()` measure real SERP pixel widths using Arial font metrics
+- **URL utilities** — `resolveCanonical()`, `normalizeUrl()`, `toSlug()`, `stripTrackingParams()`, `extractSlug()`, and more
+- **Text statistics engine** — `getTextStatistics()` returns word, sentence, paragraph, syllable, and character counts from HTML
+- **Keyword density calculator** — `calculateKeywordDensity()` and `analyzeKeyphraseOccurrences()` for single and multi-word keyphrases
+- **Robots directive builder** — `buildRobotsContent()` and `parseRobotsContent()` for structured robots meta directives
+- **Rate limiting** — token bucket implementation with `createTokenBucket()`, `consumeToken()`, and `getWaitTime()`
+- **SEO constants** — exported `TITLE_MAX_PIXELS`, `META_DESCRIPTION_MAX_PIXELS`, `KEYWORD_DENSITY`, `READABILITY`, `OG_IMAGE`, `AI_CRAWLERS`, and `SCHEMA_TYPES`
+- **25+ shared TypeScript types** — `SEOConfig`, `MetaTag`, `LinkTag`, `OpenGraphConfig`, `TwitterCardConfig`, `ContentAnalysisInput`, and more
+- **Framework-agnostic** — works in Next.js, Remix, Gatsby, Vite, vanilla Node.js, Edge
+- **Tree-shakeable** — `"sideEffects": false` with named exports per module; import only what you use
+
+![Meta Validator SERP Preview](../../image/core/meta-validator.svg)
+
+---
+
+## Comparison
+
+| Feature                              | @power-seo/core | next-seo | seo-utils | keyword-density | text-statistics |
+| ------------------------------------ | :-------------: | :------: | :-------: | :-------------: | :-------------: |
+| Meta tag builder                     | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Pixel-accurate title/meta validation | ✅              | ❌       | ❌        | ❌              | ❌              |
+| Open Graph builder                   | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Twitter Card builder                 | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Keyphrase density calculator         | ✅              | ❌       | ❌        | ✅              | ❌              |
+| Keyphrase occurrence analysis        | ✅              | ❌       | ❌        | ❌              | ❌              |
+| Robots directive builder             | ✅              | Partial  | ❌        | ❌              | ❌              |
+| URL normalization + slug             | ✅              | ❌       | Partial   | ❌              | ❌              |
+| Text statistics engine               | ✅              | ❌       | ❌        | ❌              | Partial         |
+| Title template engine                | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Hreflang builder                     | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Rate limiting utility                | ✅              | ❌       | ❌        | ❌              | ❌              |
+| 25+ shared SEO types                 | ✅              | Partial  | ❌        | ❌              | ❌              |
+| TypeScript-first                     | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Zero runtime dependencies            | ✅              | ❌       | ❌        | ❌              | ❌              |
+
+![Keyword Density Analysis](../../image/core/keyword-density.svg)
+
+---
+
+## Installation
 
 ```bash
 npm install @power-seo/core
 ```
 
-## Quick Start
-
-Build meta and link tags from an `SEOConfig` object:
-
-```typescript
-import { buildMetaTags, buildLinkTags, resolveTitle } from '@power-seo/core';
-import type { SEOConfig } from '@power-seo/core';
-
-const config: SEOConfig = {
-  title: 'My Page',
-  titleTemplate: '%s | My Site',
-  description: 'A description of the page.',
-  canonical: 'https://example.com/my-page',
-  openGraph: {
-    type: 'website',
-    url: 'https://example.com/my-page',
-    title: 'My Page',
-    description: 'A description of the page.',
-    images: [{ url: 'https://example.com/og.png', width: 1200, height: 630 }],
-  },
-};
-
-const title = resolveTitle(config); // "My Page | My Site"
-const metaTags = buildMetaTags(config);
-const linkTags = buildLinkTags(config);
+```bash
+yarn add @power-seo/core
 ```
 
-## API Reference
+```bash
+pnpm add @power-seo/core
+```
 
-### Meta Builders
+---
 
-| Export | Description |
-|---|---|
-| `buildMetaTags(config)` | Builds an array of `MetaTag` objects from SEOConfig |
-| `buildLinkTags(config)` | Builds an array of `LinkTag` objects (canonical, hreflang) |
-| `buildOpenGraphTags(config)` | Builds Open Graph meta tags |
-| `buildTwitterTags(config)` | Builds Twitter Card meta tags |
-| `buildHreflangTags(config)` | Builds hreflang link tags |
-| `resolveTitle(config)` | Resolves title with template |
+## Quick Start
 
-### Title Template
+```ts
+import { buildMetaTags, buildLinkTags, validateTitle, resolveCanonical } from '@power-seo/core';
 
-| Export | Description |
-|---|---|
-| `applyTitleTemplate(title, template)` | Applies a `%s`-based template to a title string |
-| `createTitleTemplate(vars)` | Creates a title template function from variables |
+const tags = buildMetaTags({
+  description: 'Master SEO in Next.js with structured data and meta tags.',
+  openGraph: {
+    type: 'article',
+    title: 'Next.js SEO Guide',
+    images: [{ url: 'https://example.com/og.jpg', width: 1200, height: 630 }],
+  },
+  twitter: { cardType: 'summary_large_image', site: '@mysite' },
+});
 
-### Meta Validators
+const links = buildLinkTags({
+  canonical: resolveCanonical('https://example.com', '/nextjs-seo'),
+});
 
-| Export | Description |
-|---|---|
-| `validateTitle(title)` | Returns `ValidationResult` for a title string |
-| `validateMetaDescription(desc)` | Returns `ValidationResult` for a meta description |
-| `calculatePixelWidth(text)` | Calculates approximate pixel width of text in SERPs |
+const titleCheck = validateTitle('Next.js SEO Best Practices Guide');
+console.log(titleCheck.valid);       // true
+console.log(titleCheck.pixelWidth);  // ~291 (well under 580px limit)
+```
+
+![Text Statistics Output](../../image/core/check-results.svg)
+
+**Validation severity levels:**
+- `error` — field is missing or critically invalid
+- `warning` — field exists but fails recommended limits
+- `info` — field passes all checks
+
+---
+
+## Usage
+
+### Building Meta Tags
+
+`buildMetaTags()` assembles a flat array of `MetaTag` objects from a typed `SEOConfig`. Frameworks render these into actual `<meta>` HTML elements.
+
+```ts
+import { buildMetaTags } from '@power-seo/core';
+
+const tags = buildMetaTags({
+  description: 'A TypeScript-first SEO library for modern JavaScript frameworks.',
+  robots: { index: true, follow: true, maxSnippet: 150, maxImagePreview: 'large' },
+  openGraph: {
+    type: 'website',
+    title: '@power-seo/core',
+    siteName: 'My Site',
+    locale: 'en_US',
+    images: [{ url: 'https://example.com/og.jpg', width: 1200, height: 630, alt: 'SEO Core' }],
+  },
+  twitter: {
+    cardType: 'summary_large_image',
+    site: '@mysite',
+    creator: '@author',
+    image: 'https://example.com/twitter.jpg',
+  },
+});
+// tags → MetaTag[] — pass to your framework's meta renderer
+```
+
+### Validating Titles and Meta Descriptions
+
+`validateTitle()` and `validateMetaDescription()` calculate the real pixel width Google uses for SERP truncation — not just character count.
+
+```ts
+import { validateTitle, validateMetaDescription } from '@power-seo/core';
+
+const title = validateTitle('Best Running Shoes for Beginners — 2026 Guide');
+// { valid: true, severity: 'info', charCount: 46, pixelWidth: 316.8 }
+
+const meta = validateMetaDescription('Discover expert-reviewed running shoes for beginners.');
+// { valid: true, severity: 'warning', charCount: 52, pixelWidth: 335.3 }
+// → short (under 120 chars), suggests expanding to 120–160 chars
+```
 
 ### URL Utilities
 
-| Export | Description |
-|---|---|
-| `resolveCanonical(url, base)` | Resolves a canonical URL against a base |
-| `normalizeUrl(url)` | Normalizes a URL (lowercase host, sorted params) |
-| `ensureTrailingSlash(url)` | Adds trailing slash if missing |
-| `removeTrailingSlash(url)` | Removes trailing slash |
-| `stripTrackingParams(url)` | Removes common UTM/tracking query params |
-| `extractSlug(url)` | Extracts the last path segment as a slug |
-| `toSlug(text)` | Converts arbitrary text to a URL-safe slug |
+```ts
+import {
+  resolveCanonical,
+  normalizeUrl,
+  toSlug,
+  stripTrackingParams,
+  extractSlug,
+  isAbsoluteUrl,
+} from '@power-seo/core';
+
+resolveCanonical('https://example.com', '/blog/post');
+// => "https://example.com/blog/post"
+
+toSlug('My Blog Post Title! — 2026');
+// => "my-blog-post-title-2026"
+
+stripTrackingParams('https://example.com/page?utm_source=twitter&id=123');
+// => "https://example.com/page?id=123"
+
+extractSlug('https://example.com/blog/my-post');
+// => "my-post"
+```
+
+### Keyword Density Analysis
+
+```ts
+import { calculateKeywordDensity, analyzeKeyphraseOccurrences } from '@power-seo/core';
+
+const density = calculateKeywordDensity('react seo', bodyHtml);
+// { keyword: 'react seo', count: 4, density: 1.8, totalWords: 450 }
+
+const occurrences = analyzeKeyphraseOccurrences({
+  keyphrase: 'react seo',
+  title: 'React SEO Best Practices',
+  metaDescription: 'Learn React SEO...',
+  content: htmlString,
+  slug: 'react-seo',
+  images: [{ alt: 'React SEO diagram' }],
+});
+// { inTitle: true, inH1: true, inFirstParagraph: true, density: 1.8, ... }
+```
 
 ### Text Statistics
 
-| Export | Description |
-|---|---|
-| `getTextStatistics(text)` | Returns word count, sentence count, syllable count, etc. |
-| `stripHtml(html)` | Removes HTML tags from a string |
-| `getWords(text)` | Splits text into an array of words |
-| `getSentences(text)` | Splits text into an array of sentences |
-| `countSyllables(word)` | Counts syllables in a single word |
+```ts
+import { getTextStatistics, stripHtml, getWords, getSentences } from '@power-seo/core';
 
-### Keyword Density & Robots
+const stats = getTextStatistics('<h1>Hello</h1><p>This is a test sentence. And another one.</p>');
+// {
+//   wordCount: 9,
+//   sentenceCount: 2,
+//   paragraphCount: 1,
+//   syllableCount: 11,
+//   characterCount: 42,
+//   avgWordsPerSentence: 4.5,
+//   avgSyllablesPerWord: 1.22
+// }
+```
 
-| Export | Description |
-|---|---|
-| `calculateKeywordDensity(text, keyword)` | Returns keyword density as a percentage |
-| `countKeywordOccurrences(text, keyword)` | Counts exact keyword matches in text |
-| `analyzeKeyphraseOccurrences(text, keyphrase)` | Analyzes keyphrase distribution |
-| `buildRobotsContent(directive)` | Builds a robots meta content string from a `RobotsDirective` |
-| `parseRobotsContent(content)` | Parses a robots content string into a `RobotsDirective` |
+### Robots Directives
+
+```ts
+import { buildRobotsContent, parseRobotsContent } from '@power-seo/core';
+
+buildRobotsContent({ index: false, follow: true, maxSnippet: 150, maxImagePreview: 'large' });
+// => "noindex, follow, max-snippet:150, max-image-preview:large"
+
+parseRobotsContent('noindex, follow, max-snippet:150');
+// => { index: false, follow: true, maxSnippet: 150 }
+```
+
+### Title Template Engine
+
+```ts
+import { createTitleTemplate, applyTitleTemplate } from '@power-seo/core';
+
+const makeTitle = createTitleTemplate({ siteName: 'My Site', separator: '—' });
+makeTitle('About Us');                       // => "About Us — My Site"
+makeTitle('Contact', { separator: '|' });    // => "Contact | My Site"
+
+applyTitleTemplate('%title% | %siteName% — Page %page%', {
+  title: 'Blog',
+  siteName: 'My Site',
+  page: 2,
+});
+// => "Blog | My Site — Page 2"
+```
+
+### Rate Limiting
+
+```ts
+import { createTokenBucket, consumeToken, getWaitTime, sleep } from '@power-seo/core';
+
+const bucket = createTokenBucket(60); // 60 requests per minute
+
+async function callApi() {
+  if (!consumeToken(bucket)) {
+    const waitMs = getWaitTime(bucket);
+    await sleep(waitMs);
+  }
+  // make your rate-limited API call
+}
+```
+
+### Inside a CI Content Quality Gate
+
+Block deploys when keyword density or word count fail:
+
+```ts
+import { calculateKeywordDensity, getTextStatistics } from '@power-seo/core';
+
+const stats = getTextStatistics(bodyHtml);
+const density = calculateKeywordDensity(keyphrase, bodyHtml);
+
+if (stats.wordCount < 300) {
+  console.error(`✗ Word count too low: ${stats.wordCount} (minimum 300)`);
+  process.exit(1);
+}
+
+if (density.density < 0.5 || density.density > 2.5) {
+  console.error(`✗ Keyword density out of range: ${density.density}% (target 0.5–2.5%)`);
+  process.exit(1);
+}
+```
+
+---
+
+## API Reference
+
+### Entry Points
+
+| Import | Description |
+| --- | --- |
+| `@power-seo/core` | All utilities, types, constants, builders, and validators |
+
+### Meta Builder Functions
+
+| Function | Description |
+| --- | --- |
+| `buildMetaTags(config)` | Build `MetaTag[]` array from `SEOConfig` |
+| `buildLinkTags(config)` | Build `LinkTag[]` including canonical and hreflang |
+| `buildOpenGraphTags(og)` | Build Open Graph `MetaTag[]` from `OpenGraphConfig` |
+| `buildTwitterTags(twitter)` | Build Twitter Card `MetaTag[]` from `TwitterCardConfig` |
+| `buildHreflangTags(alternates)` | Build hreflang `LinkTag[]` from `HreflangConfig[]` |
+| `resolveTitle(config)` | Resolve final title applying template if set |
+
+### Meta Validator Functions
+
+| Function | Description |
+| --- | --- |
+| `validateTitle(title)` | Validate title — char count, pixel width, severity |
+| `validateMetaDescription(desc)` | Validate meta description — char count, pixel width, severity |
+| `calculatePixelWidth(text)` | Calculate SERP pixel width using Arial font metrics |
+
+### URL Utility Functions
+
+| Function | Description |
+| --- | --- |
+| `resolveCanonical(base, path?)` | Resolve and normalize a canonical URL |
+| `normalizeUrl(url)` | Remove default ports, double slashes, trailing slashes |
+| `ensureTrailingSlash(url)` | Add trailing slash to non-file URLs |
+| `removeTrailingSlash(url)` | Strip trailing slash from a URL |
+| `stripQueryParams(url, keep?)` | Remove all or selected query parameters |
+| `stripTrackingParams(url)` | Remove UTM, fbclid, gclid, and other tracking params |
+| `extractSlug(url)` | Extract the last path segment as a slug |
+| `isAbsoluteUrl(url)` | Check whether a URL is absolute |
+| `toSlug(text)` | Convert any string to a URL-safe slug |
+
+### Text Statistics Functions
+
+| Function | Description |
+| --- | --- |
+| `getTextStatistics(content)` | Full stats — word, sentence, paragraph, syllable counts |
+| `stripHtml(html)` | Strip HTML tags, decode entities, return plain text |
+| `getWords(text)` | Split text into individual words |
+| `getSentences(text)` | Split text into sentences |
+| `getParagraphs(html)` | Extract paragraph blocks from HTML |
+| `countSyllables(word)` | Count syllables in a single word |
+| `countTotalSyllables(text)` | Count total syllables across all words in text |
+
+### Keyword Density Functions
+
+| Function | Description |
+| --- | --- |
+| `calculateKeywordDensity(keyword, content)` | Density %, occurrence count, word total |
+| `countKeywordOccurrences(text, keyword)` | Count keyword occurrences (case-insensitive, word-boundary) |
+| `analyzeKeyphraseOccurrences(config)` | Full occurrence map — title, H1, meta, slug, alt text |
+
+### Robots Builder Functions
+
+| Function | Description |
+| --- | --- |
+| `buildRobotsContent(directive)` | Serialize `RobotsDirective` to robots meta content string |
+| `parseRobotsContent(content)` | Parse robots meta content string to `RobotsDirective` |
+
+### Title Template Functions
+
+| Function | Description |
+| --- | --- |
+| `applyTitleTemplate(template, vars)` | Apply `%variable%` substitution to a title template |
+| `createTitleTemplate(defaults)` | Create a reusable title factory with site-wide defaults |
+
+### Rate Limiting Functions
+
+| Function | Description |
+| --- | --- |
+| `createTokenBucket(requestsPerMinute)` | Create a token bucket with capacity and refill rate |
+| `consumeToken(bucket)` | Consume one token; returns `true` if allowed |
+| `getWaitTime(bucket)` | Milliseconds to wait before next allowed request |
+| `sleep(ms)` | Promise-based sleep utility |
+
+### Constants
+
+| Constant | Value | Description |
+| --- | --- | --- |
+| `TITLE_MAX_PIXELS` | `580` | Google SERP max title display width (pixels) |
+| `TITLE_MAX_LENGTH` | `60` | Recommended max title character length |
+| `TITLE_MIN_LENGTH` | `50` | Recommended min title character length |
+| `META_DESCRIPTION_MAX_PIXELS` | `920` | Google SERP max meta description width (pixels) |
+| `META_DESCRIPTION_MAX_LENGTH` | `160` | Recommended max meta description length |
+| `META_DESCRIPTION_MIN_LENGTH` | `120` | Recommended min meta description length |
+| `MIN_WORD_COUNT` | `300` | Minimum word count to avoid thin content |
+| `RECOMMENDED_WORD_COUNT` | `1000` | Recommended word count for blog posts |
+| `MAX_URL_LENGTH` | `75` | Maximum recommended URL length for SEO |
+| `KEYWORD_DENSITY` | `{ MIN: 0.5, MAX: 2.5, OPTIMAL: 1.5 }` | Optimal keyword density range (%) |
+| `READABILITY` | `{ FLESCH_EASE_GOOD: 60, MAX_SENTENCE_LENGTH: 20, ... }` | Readability scoring thresholds |
+| `OG_IMAGE` | `{ WIDTH: 1200, HEIGHT: 630, ASPECT_RATIO: 1.91 }` | Open Graph recommended image dimensions |
+| `TWITTER_IMAGE` | `{ SUMMARY: { WIDTH: 144, HEIGHT: 144 }, SUMMARY_LARGE: { WIDTH: 800, HEIGHT: 418 } }` | Twitter Card recommended image dimensions |
+| `AI_CRAWLERS` | `['GPTBot', 'ClaudeBot', 'CCBot', ...]` | Common AI crawler user agents |
+| `SCHEMA_TYPES` | `['Article', 'Product', 'FAQPage', ...]` | Common Schema.org types used in SEO |
+
+### Types
+
+| Type | Description |
+| --- | --- |
+| `SEOConfig` | Full SEO configuration with title, meta, robots, OG, Twitter |
+| `MetaTag` | `{ name?, property?, httpEquiv?, content }` |
+| `LinkTag` | `{ rel, href, hreflang?, type?, sizes?, media? }` |
+| `OpenGraphConfig` | OG configuration with type, images, videos, article, profile |
+| `OpenGraphType` | `'website' \| 'article' \| 'book' \| 'profile' \| 'product' \| ...` |
+| `OpenGraphImage` | `{ url, secureUrl?, type?, width?, height?, alt? }` |
+| `TwitterCardConfig` | Twitter Card with card type, site, image, player, app |
+| `TwitterCardType` | `'summary' \| 'summary_large_image' \| 'app' \| 'player'` |
+| `RobotsDirective` | `{ index?, follow?, noarchive?, maxSnippet?, maxImagePreview?, ... }` |
+| `HreflangConfig` | `{ hrefLang, href }` |
+| `ContentAnalysisInput` | Input for content analysis — title, meta, content, keyphrase |
+| `ContentAnalysisOutput` | Output with score, maxScore, results, recommendations |
+| `AnalysisResult` | `{ id, title, description, status, score, maxScore }` |
+| `AnalysisStatus` | `'good' \| 'ok' \| 'poor'` |
+| `ReadabilityInput` | `{ content, locale? }` |
+| `ReadabilityOutput` | Flesch scores, passive voice %, transition word % |
+| `TextStatistics` | `{ wordCount, sentenceCount, paragraphCount, syllableCount, characterCount, ... }` |
+| `SitemapURL` | `{ loc, lastmod?, changefreq?, priority?, images?, videos?, news? }` |
+| `SitemapConfig` | `{ hostname, urls, maxUrlsPerSitemap?, outputDir? }` |
+| `RedirectRule` | `{ source, destination, statusCode, isRegex? }` |
+| `SchemaBase` | `{ '@context'?, '@type', '@id'?, [key]: unknown }` |
+| `SchemaGraphConfig` | `{ '@context': 'https://schema.org', '@graph': SchemaBase[] }` |
+| `KeywordDensityResult` | `{ keyword, count, density, totalWords }` |
+| `KeyphraseOccurrences` | Full occurrence map — title, H1, meta, slug, alt text, density |
+| `TokenBucket` | `{ tokens, lastRefill, maxTokens, refillRate }` |
+| `ValidationResult` | `{ valid, severity, message, charCount?, pixelWidth? }` |
+| `ValidationSeverity` | `'error' \| 'warning' \| 'info'` |
+| `TitleTemplateVars` | `{ title?, siteName?, separator?, tagline?, page?, [key]: string \| number }` |
+
+---
+
+## Use Cases
+
+- **@power-seo packages** — all 17 packages use `@power-seo/core` as a peer dependency for shared types, constants, and utilities
+- **Custom SEO libraries** — build your own SEO tooling on top of core's typed primitives without starting from scratch
+- **Next.js / Remix apps** — use `buildMetaTags()` and `buildLinkTags()` server-side in route handlers or layout components
+- **Content editors** — validate title and meta description SERP pixel widths in real time before publishing
+- **CI content quality gates** — check keyword density and word count programmatically in build pipelines
+- **eCommerce product pages** — validate product titles, descriptions, and slug quality at scale
+- **Rate-limited API integrations** — use the token bucket to respect rate limits for Google Search Console, Semrush, or Ahrefs APIs
+- **Headless CMS plugins** — use `analyzeKeyphraseOccurrences()` to show Yoast-style keyphrase feedback to editors
+
+---
+
+## Architecture Overview
+
+- **Pure TypeScript** — no compiled binary, no native modules
+- **Zero runtime dependencies** — ships clean with nothing else to install
+- **Framework-agnostic** — works in any JavaScript environment with no assumptions about React, Vue, or any framework
+- **SSR compatible** — safe to run in Next.js Server Components, Remix loaders, or Express handlers
+- **Edge runtime safe** — no Node.js-specific APIs; runs in Cloudflare Workers, Vercel Edge, Deno Deploy
+- **Tree-shakeable** — `"sideEffects": false` with named exports per module; import only what you use
+- **Dual ESM + CJS** — ships both formats via tsup for any bundler or `require()` usage
+
+---
+
+## Supply Chain Security
+
+- No install scripts (`postinstall`, `preinstall`)
+- No runtime network access
+- No `eval` or dynamic code execution
+- npm provenance enabled — every release is signed via Sigstore through GitHub Actions
+- CI-signed builds — all releases published via verified `github.com/CyberCraftBD/power-seo` workflow
+- Safe for SSR, Edge, and server environments
+
+---
+
+## The [@power-seo](https://www.npmjs.com/org/power-seo) Ecosystem
+
+All 17 packages are independently installable — use only what you need.
+
+| Package                                                                                    | Install                             | Description                                                             |
+| ------------------------------------------------------------------------------------------ | ----------------------------------- | ----------------------------------------------------------------------- |
+| [`@power-seo/core`](https://www.npmjs.com/package/@power-seo/core)                         | `npm i @power-seo/core`             | Framework-agnostic utilities, types, validators, and constants          |
+| [`@power-seo/react`](https://www.npmjs.com/package/@power-seo/react)                       | `npm i @power-seo/react`            | React SEO components — meta, Open Graph, Twitter Card, breadcrumbs      |
+| [`@power-seo/meta`](https://www.npmjs.com/package/@power-seo/meta)                         | `npm i @power-seo/meta`             | SSR meta helpers for Next.js App Router, Remix v2, and generic SSR      |
+| [`@power-seo/schema`](https://www.npmjs.com/package/@power-seo/schema)                     | `npm i @power-seo/schema`           | Type-safe JSON-LD structured data — 20 builders + 18 React components   |
+| [`@power-seo/content-analysis`](https://www.npmjs.com/package/@power-seo/content-analysis) | `npm i @power-seo/content-analysis` | Yoast-style SEO content scoring engine with React components            |
+| [`@power-seo/readability`](https://www.npmjs.com/package/@power-seo/readability)           | `npm i @power-seo/readability`      | Readability scoring — Flesch-Kincaid, Gunning Fog, Coleman-Liau, ARI    |
+| [`@power-seo/preview`](https://www.npmjs.com/package/@power-seo/preview)                   | `npm i @power-seo/preview`          | SERP, Open Graph, and Twitter/X Card preview generators                 |
+| [`@power-seo/sitemap`](https://www.npmjs.com/package/@power-seo/sitemap)                   | `npm i @power-seo/sitemap`          | XML sitemap generation, streaming, index splitting, and validation      |
+| [`@power-seo/redirects`](https://www.npmjs.com/package/@power-seo/redirects)               | `npm i @power-seo/redirects`        | Redirect engine with Next.js, Remix, and Express adapters               |
+| [`@power-seo/links`](https://www.npmjs.com/package/@power-seo/links)                       | `npm i @power-seo/links`            | Link graph analysis — orphan detection, suggestions, equity scoring     |
+| [`@power-seo/audit`](https://www.npmjs.com/package/@power-seo/audit)                       | `npm i @power-seo/audit`            | Full SEO audit engine — meta, content, structure, performance rules     |
+| [`@power-seo/images`](https://www.npmjs.com/package/@power-seo/images)                     | `npm i @power-seo/images`           | Image SEO — alt text, lazy loading, format analysis, image sitemaps     |
+| [`@power-seo/ai`](https://www.npmjs.com/package/@power-seo/ai)                             | `npm i @power-seo/ai`               | LLM-agnostic AI prompt templates and parsers for SEO tasks              |
+| [`@power-seo/analytics`](https://www.npmjs.com/package/@power-seo/analytics)               | `npm i @power-seo/analytics`        | Merge GSC + audit data, trend analysis, ranking insights, dashboard     |
+| [`@power-seo/search-console`](https://www.npmjs.com/package/@power-seo/search-console)     | `npm i @power-seo/search-console`   | Google Search Console API — OAuth2, service account, URL inspection     |
+| [`@power-seo/integrations`](https://www.npmjs.com/package/@power-seo/integrations)         | `npm i @power-seo/integrations`     | Semrush and Ahrefs API clients with rate limiting and pagination        |
+| [`@power-seo/tracking`](https://www.npmjs.com/package/@power-seo/tracking)                 | `npm i @power-seo/tracking`         | GA4, Clarity, PostHog, Plausible, Fathom — scripts + consent management |
+
+---
+
+## Keywords
+
+seo utilities typescript · meta tag builder npm · pixel-accurate serp validator · keyword density calculator typescript · url normalization seo · canonical url builder · text statistics library · open graph meta tag builder · twitter card builder · hreflang link tag generator · robots directive builder · title template engine · seo primitives library · framework-agnostic seo utilities · token bucket rate limiter · seo types typescript · slug generator npm · html text extractor · nextjs seo utilities · seo constants npm · serp pixel width calculator · keyphrase occurrence analyzer · seo foundation package · shared seo types monorepo · seo utility functions typescript · meta description validator · structured data types typescript
+
+---
+
+## About [CyberCraft Bangladesh](https://ccbd.dev)
+
+**[CyberCraft Bangladesh](https://ccbd.dev)** is a Bangladesh-based enterprise-grade software development and Full Stack SEO service provider company specializing in ERP system development, AI-powered SaaS and business applications, full-stack SEO services, custom website development, and scalable eCommerce platforms. We design and develop intelligent, automation-driven SaaS and enterprise solutions that help startups, SMEs, NGOs, educational institutes, and large organizations streamline operations, enhance digital visibility, and accelerate growth through modern cloud-native technologies.
+
+[![Website](https://img.shields.io/badge/Website-ccbd.dev-blue?style=for-the-badge)](https://ccbd.dev)
+[![GitHub](https://img.shields.io/badge/GitHub-cybercraftbd-black?style=for-the-badge&logo=github)](https://github.com/cybercraftbd)
+[![npm](https://img.shields.io/badge/npm-power--seo-red?style=for-the-badge&logo=npm)](https://www.npmjs.com/org/power-seo)
+[![Email](https://img.shields.io/badge/Email-info@ccbd.dev-green?style=for-the-badge&logo=gmail)](mailto:info@ccbd.dev)
+
+© 2026 [CyberCraft Bangladesh](https://ccbd.dev) · Released under the [MIT License](../../LICENSE)

--- a/packages/ai/tsup.config.ts
+++ b/packages/ai/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
 });

--- a/packages/analytics/tsup.config.ts
+++ b/packages/analytics/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
 });

--- a/packages/audit/tsup.config.ts
+++ b/packages/audit/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
 });

--- a/packages/content-analysis/README.md
+++ b/packages/content-analysis/README.md
@@ -14,7 +14,7 @@ Keyword-focused content analysis with real-time scoring, readability checks, and
 
 `@power-seo/content-analysis` delivers a comprehensive, WordPress SEO plugin–style scoring pipeline for evaluating text content, comparable to Yoast SEO, All in One SEO (AIOSEO), Rank Math, SEOPress, and The SEO Framework. Provide a page title, meta description, body content, focus keyphrase, images, and links — get back structured `good` / `needs-improvement` / `poor` results across all critical SEO factors. Run it server-side in a CMS, client-side in a React editor, or inside a CI content quality gate. All 13 analysis checks are fully configurable and tree-shakeable.
 
-> **Zero runtime dependencies** — only `@power-seo/core` as a peer.
+> **Zero external runtime dependencies** — `@power-seo/core` is a direct dependency bundled with this package; no extra install needed.
 
 ---
 
@@ -82,15 +82,15 @@ Keyword-focused content analysis with real-time scoring, readability checks, and
 ## Installation
 
 ```bash
-npm install @power-seo/content-analysis @power-seo/core
+npm install @power-seo/content-analysis
 ```
 
 ```bash
-yarn add @power-seo/content-analysis @power-seo/core
+yarn add @power-seo/content-analysis
 ```
 
 ```bash
-pnpm add @power-seo/content-analysis @power-seo/core
+pnpm add @power-seo/content-analysis
 ```
 
 ---
@@ -103,14 +103,14 @@ import { analyzeContent } from '@power-seo/content-analysis';
 const result = analyzeContent({
   title: 'Best Running Shoes for Beginners',
   metaDescription: 'Discover the best running shoes for beginners with our expert guide.',
-  keyphrase: 'running shoes for beginners',
+  focusKeyphrase: 'running shoes for beginners',
   content: '<h1>Best Running Shoes</h1><p>Finding the right running shoes...</p>',
-  url: 'https://example.com/best-running-shoes',
 });
 
-console.log(result.overallStatus); // "good" | "needs-improvement" | "poor"
+console.log(result.score);      // e.g. 38
+console.log(result.maxScore);   // e.g. 55
 console.log(result.results);
-// [{ id: 'title-presence', status: 'good', message: '...' }, ...]
+// [{ id: 'title-presence', status: 'good', description: '...', score: 5, maxScore: 5 }, ...]
 ```
 
 ![SEO Check Results](../../image/content-analysis/check-results.svg)
@@ -134,16 +134,16 @@ import { analyzeContent } from '@power-seo/content-analysis';
 const output = analyzeContent({
   title: 'Next.js SEO Best Practices',
   metaDescription: 'Learn how to optimize your Next.js app for search engines with meta tags and structured data.',
-  keyphrase: 'next.js seo',
+  focusKeyphrase: 'next.js seo',
   content: htmlString,
-  url: 'https://example.com/nextjs-seo',
   images: imageList,
   internalLinks: internalLinks,
   externalLinks: externalLinks,
 });
 
-// output.overallStatus  → 'good' | 'needs-improvement' | 'poor'
-// output.results        → AnalysisResult[]
+// output.score      → number (sum of all check scores)
+// output.maxScore   → number (maximum possible score)
+// output.results    → AnalysisResult[]
 ```
 
 ### Running Individual Checks
@@ -162,15 +162,17 @@ import {
 } from '@power-seo/content-analysis';
 
 const titleResults = checkTitle({
-  title: 'React SEO Guide',
-  keyphrase: 'react seo',
   content: '',
+  title: 'React SEO Guide',
+  focusKeyphrase: 'react seo',
 });
-// [{ id: 'title-presence', status: 'good', message: '...' },
-//  { id: 'title-keyphrase', status: 'good', message: '...' }]
+// [
+//   { id: 'title-presence', title: 'SEO title', description: '...', status: 'good', score: 5, maxScore: 5 },
+//   { id: 'title-keyphrase', title: 'Keyphrase in title', description: '...', status: 'good', score: 5, maxScore: 5 }
+// ]
 
 const wcResult = checkWordCount({ content: shortHtml });
-// { id: 'word-count', status: 'poor', message: 'Content is 180 words, below minimum of 300.' }
+// { id: 'word-count', title: 'Word count', description: 'The content is 180 words...', status: 'poor', score: 1, maxScore: 5 }
 ```
 
 ### Disabling Specific Checks
@@ -217,13 +219,13 @@ Block deploys when SEO checks fail:
 ```ts
 import { analyzeContent } from '@power-seo/content-analysis';
 
-const output = analyzeContent({ title, metaDescription, keyphrase, content });
+const output = analyzeContent({ title, metaDescription, focusKeyphrase, content });
 
 const failures = output.results.filter((r) => r.status === 'poor');
 
 if (failures.length > 0) {
   console.error('SEO checks failed:');
-  failures.forEach((r) => console.error(' ✗', r.message));
+  failures.forEach((r) => console.error(' ✗', r.description));
   process.exit(1);
 }
 ```
@@ -255,31 +257,31 @@ function analyzeContent(
 | `content`         | `string`                               | ✅       | Body HTML string                               |
 | `title`           | `string`                               | —        | Page `<title>` content                         |
 | `metaDescription` | `string`                               | —        | Meta description content                       |
-| `keyphrase`       | `string`                               | —        | Focus keyphrase to analyze against             |
-| `url`             | `string`                               | —        | Page URL (used for slug analysis)              |
+| `focusKeyphrase`  | `string`                               | —        | Focus keyphrase to analyze against             |
+| `slug`            | `string`                               | —        | URL slug (used for keyphrase-in-slug check)    |
 | `images`          | `Array<{ src: string; alt?: string }>` | —        | Images found on the page                       |
 | `internalLinks`   | `string[]`                             | —        | Internal link URLs                             |
 | `externalLinks`   | `string[]`                             | —        | External link URLs                             |
 
 #### `ContentAnalysisOutput`
 
-| Field           | Type               | Description                                               |
-| --------------- | ------------------ | --------------------------------------------------------- |
-| `overallStatus` | `AnalysisStatus`   | `'good'` \| `'needs-improvement'` \| `'poor'`            |
-| `score`         | `number`           | Sum of all individual check scores                        |
-| `maxScore`      | `number`           | Maximum possible score (varies by enabled checks)         |
-| `results`       | `AnalysisResult[]` | Per-check results                                         |
-| `recommendations` | `string[]`       | Descriptions from all failed or partial checks            |
+| Field             | Type               | Description                                           |
+| ----------------- | ------------------ | ----------------------------------------------------- |
+| `score`           | `number`           | Sum of all individual check scores                    |
+| `maxScore`        | `number`           | Maximum possible score (varies by enabled checks)     |
+| `results`         | `AnalysisResult[]` | Per-check results                                     |
+| `recommendations` | `string[]`         | Descriptions from all failed or partial checks        |
 
 #### `AnalysisResult`
 
-| Field     | Type             | Description                                   |
-| --------- | ---------------- | --------------------------------------------- |
-| `id`      | `CheckId`        | Unique check identifier (see table below)     |
-| `status`  | `AnalysisStatus` | `'good'` \| `'needs-improvement'` \| `'poor'` |
-| `message` | `string`         | Human-readable actionable feedback            |
-| `score`   | `number`         | Points earned for this check                  |
-| `maxScore`| `number`         | Maximum points for this check                 |
+| Field         | Type             | Description                                               |
+| ------------- | ---------------- | --------------------------------------------------------- |
+| `id`          | `string`         | Unique check identifier (one of the `CheckId` values)     |
+| `title`       | `string`         | Short display label for the check (e.g. `"SEO title"`)    |
+| `description` | `string`         | Human-readable actionable feedback                        |
+| `status`      | `AnalysisStatus` | `'good'` \| `'ok'` \| `'poor'`                            |
+| `score`       | `number`         | Points earned for this check                              |
+| `maxScore`    | `number`         | Maximum points for this check                             |
 
 #### `AnalysisConfig`
 
@@ -289,15 +291,17 @@ function analyzeContent(
 
 ### Individual Check Functions
 
-| Function                      | Check ID(s)                                                    | Checks For                                         |
-| ----------------------------- | -------------------------------------------------------------- | -------------------------------------------------- |
-| `checkTitle(input)`           | `title-presence`, `title-keyphrase`                            | Title presence, length (30–60 chars), keyphrase    |
-| `checkMetaDescription(input)` | `meta-description-presence`, `meta-description-keyphrase`      | Description presence, length (120–160 chars), keyphrase |
-| `checkKeyphraseUsage(input)`  | `keyphrase-density`, `keyphrase-distribution`                  | Density (0.5–2.5%) and occurrence in key areas     |
-| `checkHeadings(input)`        | `heading-structure`, `heading-keyphrase`                       | H1 presence, hierarchy, keyphrase in subheadings   |
-| `checkWordCount(input)`       | `word-count`                                                   | Min 300 words (good at 1,000+)                     |
-| `checkImages(input)`          | `image-alt`, `image-keyphrase`                                 | Alt text presence and keyphrase in alt             |
-| `checkLinks(input)`           | `internal-links`, `external-links`                             | Internal and external link presence                |
+| Function                      | Check ID(s)                                                    | Checks For                                                                                  |
+| ----------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `checkTitle(input)`           | `title-presence`, `title-keyphrase`                            | Title presence **and** length (50–60 chars, validated inside `title-presence`), keyphrase    |
+| `checkMetaDescription(input)` | `meta-description-presence`, `meta-description-keyphrase`      | Description presence, length (120–160 chars), keyphrase                                     |
+| `checkKeyphraseUsage(input)`  | `keyphrase-density`, `keyphrase-distribution`                  | Density (0.5–2.5%) and occurrence in key areas                                              |
+| `checkHeadings(input)`        | `heading-structure`, `heading-keyphrase`                       | H1 presence, hierarchy, keyphrase in subheadings                                            |
+| `checkWordCount(input)`       | `word-count`                                                   | Min 300 words (good at 1,000+)                                                              |
+| `checkImages(input)`          | `image-alt`, `image-keyphrase`                                 | Alt text presence and keyphrase in alt                                                      |
+| `checkLinks(input)`           | `internal-links`, `external-links`                             | Internal and external link presence                                                         |
+
+> **Note:** There is no separate `title-length` check ID. Title length validation (50–60 chars) is evaluated inside the `title-presence` check — a title that exists but is outside the recommended range returns `status: 'ok'` rather than `'good'`.
 
 ### Types
 
@@ -305,10 +309,10 @@ function analyzeContent(
 | ----------------------- | --------------------------------------------------------- |
 | `CheckId`               | Union of all 13 built-in check IDs                        |
 | `AnalysisConfig`        | `{ disabledChecks?: CheckId[] }`                          |
-| `AnalysisStatus`        | `'good' \| 'needs-improvement' \| 'poor'`                 |
+| `AnalysisStatus`        | `'good' \| 'ok' \| 'poor'`                               |
 | `ContentAnalysisInput`  | Input shape for `analyzeContent()`                        |
 | `ContentAnalysisOutput` | Output shape from `analyzeContent()`                      |
-| `AnalysisResult`        | Single check result with id, status, message, score       |
+| `AnalysisResult`        | Single check result with id, title, description, status, score, maxScore |
 
 ---
 
@@ -326,7 +330,7 @@ function analyzeContent(
 ## Architecture Overview
 
 - **Pure TypeScript** — no compiled binary, no native modules
-- **Zero runtime dependencies** — only `@power-seo/core` as a peer dependency
+- **Zero external runtime dependencies** — `@power-seo/core` ships as a direct dependency, no separate install
 - **Framework-agnostic** — works in any JavaScript environment
 - **SSR compatible** — safe to run in Next.js Server Components, Remix loaders, or Express handlers
 - **Edge runtime safe** — no Node.js-specific APIs; runs in Cloudflare Workers, Vercel Edge, Deno

--- a/packages/content-analysis/README.md
+++ b/packages/content-analysis/README.md
@@ -12,7 +12,7 @@ Keyword-focused content analysis with real-time scoring, readability checks, and
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
 [![tree-shakeable](https://img.shields.io/badge/tree--shakeable-yes-brightgreen)](https://bundlephobia.com/package/@power-seo/content-analysis)
 
-`@power-seo/content-analysis` delivers a comprehensive, WordPress SEO plugin–style scoring pipeline for evaluating text content, comparable to Yoast SEO, All in One SEO (AIOSEO), Rank Math, SEOPress, and The SEO Framework. Provide a page title, meta description, body content, focus keyphrase, images, and links — get back structured `good` / `needs-improvement` / `poor` results across all critical SEO factors. Run it server-side in a CMS, client-side in a React editor, or inside a CI content quality gate. All 13 analysis checks are fully configurable and tree-shakeable.
+`@power-seo/content-analysis` delivers a comprehensive, WordPress SEO plugin–style scoring pipeline for evaluating text content, comparable to Yoast SEO, All in One SEO (AIOSEO), Rank Math, SEOPress, and The SEO Framework. Provide a page title, meta description, body content, focus keyphrase, images, and links — get back structured `good` / `ok` / `poor` results across all critical SEO factors. Run it server-side in a CMS, client-side in a React editor, or inside a CI content quality gate. All 13 analysis checks are fully configurable and tree-shakeable.
 
 > **Zero external runtime dependencies** — `@power-seo/core` is a direct dependency bundled with this package; no extra install needed.
 
@@ -117,7 +117,7 @@ console.log(result.results);
 
 **Status thresholds (per check):**
 - `good` — check fully passes
-- `needs-improvement` — check partially passes
+- `ok` — check partially passes
 - `poor` — check fails
 
 ---
@@ -177,7 +177,7 @@ const wcResult = checkWordCount({ content: shortHtml });
 
 ### Disabling Specific Checks
 
-Pass `config.disabledChecks` to skip checks that don't apply to your content type:
+Pass `config.disabledChecks` to exclude specific checks from the output. Checks are still executed internally but their results are filtered from `output.results` and excluded from `score`/`maxScore` totals. Invalid check IDs are silently ignored.
 
 ```ts
 import { analyzeContent } from '@power-seo/content-analysis';
@@ -193,6 +193,7 @@ Import from the `/react` entry point for pre-built analysis UI components:
 
 ```tsx
 import { ContentAnalyzer, ScorePanel, CheckList } from '@power-seo/content-analysis/react';
+import { analyzeContent } from '@power-seo/content-analysis';
 import type { ContentAnalysisInput } from '@power-seo/content-analysis';
 
 // All-in-one component

--- a/packages/content-analysis/tsup.config.ts
+++ b/packages/content-analysis/tsup.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
   external: ['react', 'react-dom'],
 });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,51 +1,86 @@
-# @power-seo/core — Framework-Agnostic SEO Utilities for TypeScript & React
+# @power-seo/core
 
-> Zero-dependency foundation for the @power-seo toolkit. Provides shared types, meta tag builders, URL utilities, text statistics, keyword density analysis, robots directive builder, validators, and constants.
+![core banner](../../image/core/banner.svg)
+
+Framework-agnostic SEO utilities, types, and engines — the shared foundation of the entire @power-seo ecosystem, usable as a standalone TypeScript library that works anywhere.
 
 [![npm version](https://img.shields.io/npm/v/@power-seo/core)](https://www.npmjs.com/package/@power-seo/core)
 [![npm downloads](https://img.shields.io/npm/dm/@power-seo/core)](https://www.npmjs.com/package/@power-seo/core)
+[![Socket](https://socket.dev/api/badge/npm/package/@power-seo/core)](https://socket.dev/npm/package/@power-seo/core)
+[![npm provenance](https://img.shields.io/badge/npm-provenance-enabled-blue)](https://github.com/CyberCraftBD/power-seo/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
 [![tree-shakeable](https://img.shields.io/badge/tree--shakeable-yes-brightgreen)](https://bundlephobia.com/package/@power-seo/core)
 
-The foundation package used by all other `@power-seo` packages. Useful on its own for headless SEO tooling, custom framework integrations, or any Node.js application that needs SEO utilities without a React dependency.
+`@power-seo/core` is the foundational library shared by all 17 `@power-seo` packages. It delivers pixel-accurate meta validators, structured meta and link tag builders, URL normalization, keyword density analysis, text statistics, Open Graph and Twitter Card builders, robots directive generation, title template engines, and a token-bucket rate limiter — all in a single zero-dependency TypeScript package. Think of it as combining `next-seo`, `seo-utils`, `keyword-density`, `url-normalize`, and `text-statistics` into one unified, tree-shakeable library that runs in Next.js, Remix, Vite, vanilla Node.js, Cloudflare Workers, and Vercel Edge. All 9 utility modules are fully configurable and independently importable.
 
-## Documentation
+> **Zero runtime dependencies** — installs clean with nothing else to pull in.
 
-- **Package docs:** [`apps/docs/src/content/docs/packages/core.mdx`](../../apps/docs/src/content/docs/packages/core.mdx)
-- **Ecosystem overview:** [`README.md`](../../README.md)
-- **Contributing guide:** [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+---
+
+## Why @power-seo/core?
+
+| | Without | With |
+|---|---|---|
+| Meta tag building | ❌ Hand-written HTML strings | ✅ Type-safe `buildMetaTags()` with OG + Twitter |
+| Title validation | ❌ Character count only | ✅ Pixel-accurate SERP width via `validateTitle()` |
+| Keyword density | ❌ Manual regex counting | ✅ `calculateKeywordDensity()` with density % |
+| URL canonicalization | ❌ String manipulation | ✅ `resolveCanonical()` with full normalization |
+| Text statistics | ❌ Multiple separate packages | ✅ `getTextStatistics()` — words, sentences, syllables |
+| Robots directives | ❌ Concatenated strings | ✅ Type-safe `buildRobotsContent()` builder |
+| Title templates | ❌ Manual string interpolation | ✅ `createTitleTemplate()` with site-wide defaults |
+| Rate limiting | ❌ No built-in utility | ✅ Token bucket `createTokenBucket()` for API calls |
+| TypeScript types | ❌ Duplicated across packages | ✅ 25+ shared interfaces for the full ecosystem |
+
+![SEO Utilities Dashboard](../../image/core/utilities-dashboard.svg)
+
+---
 
 ## Features
 
-- **Meta tag builders** — generate typed `MetaTag[]` and `LinkTag[]` objects for title, description, Open Graph, Twitter Card, hreflang
-- **Robots directive builder** — build and parse robots meta content strings with full directive support (noindex, nofollow, max-snippet, max-image-preview, max-video-preview, unavailable_after, noarchive, nosnippet, noimageindex, notranslate)
-- **Title template engine** — `%s | Site Name` style templates with `applyTitleTemplate()`
-- **Meta validators** — validate title and description length in both characters and pixel width
-- **URL utilities** — normalize, slug-ify, strip tracking params, resolve canonical, check absolute/relative
-- **Text statistics** — word count, sentence count, syllable count, paragraph count from HTML content
-- **Keyword density analysis** — calculate density, count occurrences, analyze keyphrase distribution
-- **Shared constants** — `TITLE_MAX_LENGTH`, `META_DESCRIPTION_MAX_LENGTH`, `OG_IMAGE`, `KEYWORD_DENSITY` thresholds
-- **Zero runtime dependencies** — safe to use in any environment including edge runtimes
-- **Dual ESM + CJS** — works with any bundler or Node.js require
-- **TypeScript-first** — all types exported, full `.d.ts` declarations
+- **Meta tag builder** — `buildMetaTags()` generates typed arrays of meta tags from a structured `SEOConfig`
+- **Open Graph builder** — `buildOpenGraphTags()` with full support for article, profile, book, video, and music OG types
+- **Twitter Card builder** — `buildTwitterTags()` for summary, large image, player, and app card types
+- **Hreflang builder** — `buildHreflangTags()` generates `<link rel="alternate">` tags for multi-language pages
+- **Title template engine** — `applyTitleTemplate()` and `createTitleTemplate()` with `%variable%` substitution and separator cleanup
+- **Pixel-accurate meta validators** — `validateTitle()` and `validateMetaDescription()` measure real SERP pixel widths using Arial font metrics
+- **URL utilities** — `resolveCanonical()`, `normalizeUrl()`, `toSlug()`, `stripTrackingParams()`, `extractSlug()`, and more
+- **Text statistics engine** — `getTextStatistics()` returns word, sentence, paragraph, syllable, and character counts from HTML
+- **Keyword density calculator** — `calculateKeywordDensity()` and `analyzeKeyphraseOccurrences()` for single and multi-word keyphrases
+- **Robots directive builder** — `buildRobotsContent()` and `parseRobotsContent()` for structured robots meta directives
+- **Rate limiting** — token bucket implementation with `createTokenBucket()`, `consumeToken()`, and `getWaitTime()`
+- **SEO constants** — exported `TITLE_MAX_PIXELS`, `META_DESCRIPTION_MAX_PIXELS`, `KEYWORD_DENSITY`, `READABILITY`, `OG_IMAGE`, `AI_CRAWLERS`, and `SCHEMA_TYPES`
+- **25+ shared TypeScript types** — `SEOConfig`, `MetaTag`, `LinkTag`, `OpenGraphConfig`, `TwitterCardConfig`, `ContentAnalysisInput`, and more
+- **Framework-agnostic** — works in Next.js, Remix, Gatsby, Vite, vanilla Node.js, Edge
+- **Tree-shakeable** — `"sideEffects": false` with named exports per module; import only what you use
 
-## Table of Contents
+![Meta Validator SERP Preview](../../image/core/meta-validator.svg)
 
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [Usage](#usage)
-  - [Meta Tag Builders](#meta-tag-builders)
-  - [Robots Directive Builder](#robots-directive-builder)
-  - [Title Template Engine](#title-template-engine)
-  - [Meta Validators](#meta-validators)
-  - [URL Utilities](#url-utilities)
-  - [Text Statistics](#text-statistics)
-  - [Keyword Density](#keyword-density)
-  - [Constants](#constants)
-- [API Reference](#api-reference)
-- [The @power-seo Ecosystem](#the-power-seo-ecosystem)
-- [About CyberCraft Bangladesh](#about-cybercraft-bangladesh)
+---
+
+## Comparison
+
+| Feature                              | @power-seo/core | next-seo | seo-utils | keyword-density | text-statistics |
+| ------------------------------------ | :-------------: | :------: | :-------: | :-------------: | :-------------: |
+| Meta tag builder                     | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Pixel-accurate title/meta validation | ✅              | ❌       | ❌        | ❌              | ❌              |
+| Open Graph builder                   | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Twitter Card builder                 | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Keyphrase density calculator         | ✅              | ❌       | ❌        | ✅              | ❌              |
+| Keyphrase occurrence analysis        | ✅              | ❌       | ❌        | ❌              | ❌              |
+| Robots directive builder             | ✅              | Partial  | ❌        | ❌              | ❌              |
+| URL normalization + slug             | ✅              | ❌       | Partial   | ❌              | ❌              |
+| Text statistics engine               | ✅              | ❌       | ❌        | ❌              | Partial         |
+| Title template engine                | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Hreflang builder                     | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Rate limiting utility                | ✅              | ❌       | ❌        | ❌              | ❌              |
+| 25+ shared SEO types                 | ✅              | Partial  | ❌        | ❌              | ❌              |
+| TypeScript-first                     | ✅              | Partial  | ❌        | ❌              | ❌              |
+| Zero runtime dependencies            | ✅              | ❌       | ❌        | ❌              | ❌              |
+
+![Keyword Density Analysis](../../image/core/keyword-density.svg)
+
+---
 
 ## Installation
 
@@ -61,286 +96,386 @@ yarn add @power-seo/core
 pnpm add @power-seo/core
 ```
 
+---
+
 ## Quick Start
 
 ```ts
-import { buildMetaTags, buildRobotsContent, validateTitle, toSlug } from '@power-seo/core';
+import { buildMetaTags, buildLinkTags, validateTitle, resolveCanonical } from '@power-seo/core';
 
 const tags = buildMetaTags({
-  title: 'My Page',
-  description: 'Page description',
-  robots: { index: true, follow: true },
+  description: 'Master SEO in Next.js with structured data and meta tags.',
+  openGraph: {
+    type: 'article',
+    title: 'Next.js SEO Guide',
+    images: [{ url: 'https://example.com/og.jpg', width: 1200, height: 630 }],
+  },
+  twitter: { cardType: 'summary_large_image', site: '@mysite' },
 });
-const robots = buildRobotsContent({ index: false, maxSnippet: 150 }); // → "noindex, max-snippet:150"
-const valid = validateTitle('My Page Title'); // { valid: true, length: 14, pixelWidth: 95 }
-const slug = toSlug('My Blog Post!'); // → "my-blog-post"
+
+const links = buildLinkTags({
+  canonical: resolveCanonical('https://example.com', '/nextjs-seo'),
+});
+
+const titleCheck = validateTitle('Next.js SEO Best Practices Guide');
+console.log(titleCheck.valid);       // true
+console.log(titleCheck.pixelWidth);  // ~291 (well under 580px limit)
 ```
+
+![Text Statistics Output](../../image/core/check-results.svg)
+
+**Validation severity levels:**
+- `error` — field is missing or critically invalid
+- `warning` — field exists but fails recommended limits
+- `info` — field passes all checks
+
+---
 
 ## Usage
 
-### Meta Tag Builders
+### Building Meta Tags
+
+`buildMetaTags()` assembles a flat array of `MetaTag` objects from a typed `SEOConfig`. Frameworks render these into actual `<meta>` HTML elements.
+
+```ts
+import { buildMetaTags } from '@power-seo/core';
+
+const tags = buildMetaTags({
+  description: 'A TypeScript-first SEO library for modern JavaScript frameworks.',
+  robots: { index: true, follow: true, maxSnippet: 150, maxImagePreview: 'large' },
+  openGraph: {
+    type: 'website',
+    title: '@power-seo/core',
+    siteName: 'My Site',
+    locale: 'en_US',
+    images: [{ url: 'https://example.com/og.jpg', width: 1200, height: 630, alt: 'SEO Core' }],
+  },
+  twitter: {
+    cardType: 'summary_large_image',
+    site: '@mysite',
+    creator: '@author',
+    image: 'https://example.com/twitter.jpg',
+  },
+});
+// tags → MetaTag[] — pass to your framework's meta renderer
+```
+
+### Validating Titles and Meta Descriptions
+
+`validateTitle()` and `validateMetaDescription()` calculate the real pixel width Google uses for SERP truncation — not just character count.
+
+```ts
+import { validateTitle, validateMetaDescription } from '@power-seo/core';
+
+const title = validateTitle('Best Running Shoes for Beginners — 2026 Guide');
+// { valid: true, severity: 'info', charCount: 46, pixelWidth: 316.8 }
+
+const meta = validateMetaDescription('Discover expert-reviewed running shoes for beginners.');
+// { valid: true, severity: 'warning', charCount: 52, pixelWidth: 335.3 }
+// → short (under 120 chars), suggests expanding to 120–160 chars
+```
+
+### URL Utilities
 
 ```ts
 import {
-  buildMetaTags,
-  buildLinkTags,
-  buildOpenGraphTags,
-  buildTwitterTags,
-  buildHreflangTags,
+  resolveCanonical,
+  normalizeUrl,
+  toSlug,
+  stripTrackingParams,
+  extractSlug,
+  isAbsoluteUrl,
 } from '@power-seo/core';
 
-const meta = buildMetaTags({
-  title: 'My Page',
-  description: 'Page description',
-  robots: { index: true, follow: true },
-});
+resolveCanonical('https://example.com', '/blog/post');
+// => "https://example.com/blog/post"
 
-const links = buildLinkTags({ canonical: 'https://example.com/page' });
+toSlug('My Blog Post Title! — 2026');
+// => "my-blog-post-title-2026"
 
-const og = buildOpenGraphTags({
-  title: 'My Page',
-  description: 'Page description',
-  type: 'website',
-  url: 'https://example.com',
-  images: [{ url: 'https://example.com/og.jpg', width: 1200, height: 630 }],
-});
+stripTrackingParams('https://example.com/page?utm_source=twitter&id=123');
+// => "https://example.com/page?id=123"
 
-const twitter = buildTwitterTags({
-  card: 'summary_large_image',
-  site: '@mysite',
-  title: 'My Page',
-  description: 'Page description',
-  image: 'https://example.com/twitter.jpg',
-});
-
-const hreflang = buildHreflangTags([
-  { hrefLang: 'en', href: 'https://example.com/page' },
-  { hrefLang: 'fr', href: 'https://fr.example.com/page' },
-  { hrefLang: 'x-default', href: 'https://example.com/page' },
-]);
+extractSlug('https://example.com/blog/my-post');
+// => "my-post"
 ```
 
-### Robots Directive Builder
+### Keyword Density Analysis
+
+```ts
+import { calculateKeywordDensity, analyzeKeyphraseOccurrences } from '@power-seo/core';
+
+const density = calculateKeywordDensity('react seo', bodyHtml);
+// { keyword: 'react seo', count: 4, density: 1.8, totalWords: 450 }
+
+const occurrences = analyzeKeyphraseOccurrences({
+  keyphrase: 'react seo',
+  title: 'React SEO Best Practices',
+  metaDescription: 'Learn React SEO...',
+  content: htmlString,
+  slug: 'react-seo',
+  images: [{ alt: 'React SEO diagram' }],
+});
+// { inTitle: true, inH1: true, inFirstParagraph: true, density: 1.8, ... }
+```
+
+### Text Statistics
+
+```ts
+import { getTextStatistics, stripHtml, getWords, getSentences } from '@power-seo/core';
+
+const stats = getTextStatistics('<h1>Hello</h1><p>This is a test sentence. And another one.</p>');
+// {
+//   wordCount: 9,
+//   sentenceCount: 2,
+//   paragraphCount: 1,
+//   syllableCount: 11,
+//   characterCount: 42,
+//   avgWordsPerSentence: 4.5,
+//   avgSyllablesPerWord: 1.22
+// }
+```
+
+### Robots Directives
 
 ```ts
 import { buildRobotsContent, parseRobotsContent } from '@power-seo/core';
 
-// Build robots meta content string
-buildRobotsContent({ index: true, follow: true });
-// → "index, follow"
+buildRobotsContent({ index: false, follow: true, maxSnippet: 150, maxImagePreview: 'large' });
+// => "noindex, follow, max-snippet:150, max-image-preview:large"
 
-buildRobotsContent({ index: false, follow: false, noarchive: true });
-// → "noindex, nofollow, noarchive"
-
-buildRobotsContent({ index: true, maxSnippet: 150, maxImagePreview: 'large' });
-// → "index, max-snippet:150, max-image-preview:large"
-
-// Parse existing robots string back to config
-parseRobotsContent('noindex, follow, max-image-preview:large');
-// → { index: false, follow: true, maxImagePreview: 'large' }
+parseRobotsContent('noindex, follow, max-snippet:150');
+// => { index: false, follow: true, maxSnippet: 150 }
 ```
-
-**All supported directives:**
-
-| Directive          | Type                              | Description                                  |
-| ------------------ | --------------------------------- | -------------------------------------------- |
-| `index`            | `boolean`                         | `true` → `index`, `false` → `noindex`        |
-| `follow`           | `boolean`                         | `true` → `follow`, `false` → `nofollow`      |
-| `noarchive`        | `boolean`                         | Prevent cached version in search results     |
-| `nosnippet`        | `boolean`                         | Prevent text/video snippet in results        |
-| `noimageindex`     | `boolean`                         | Prevent page images from being indexed       |
-| `notranslate`      | `boolean`                         | Prevent Google Translate offer               |
-| `maxSnippet`       | `number`                          | Max text snippet length (e.g. `150`)         |
-| `maxImagePreview`  | `'none' \| 'standard' \| 'large'` | Max image preview size                       |
-| `maxVideoPreview`  | `number`                          | Max video preview duration in seconds        |
-| `unavailableAfter` | `string`                          | Date after which to remove page from results |
 
 ### Title Template Engine
 
 ```ts
-import { applyTitleTemplate, createTitleTemplate } from '@power-seo/core';
+import { createTitleTemplate, applyTitleTemplate } from '@power-seo/core';
 
-applyTitleTemplate('Blog Post', '%s | My Site');
-// → "Blog Post | My Site"
+const makeTitle = createTitleTemplate({ siteName: 'My Site', separator: '—' });
+makeTitle('About Us');                       // => "About Us — My Site"
+makeTitle('Contact', { separator: '|' });    // => "Contact | My Site"
 
-const template = createTitleTemplate({ separator: '|', suffix: 'My Site' });
-template.apply('Blog Post'); // → "Blog Post | My Site"
+applyTitleTemplate('%title% | %siteName% — Page %page%', {
+  title: 'Blog',
+  siteName: 'My Site',
+  page: 2,
+});
+// => "Blog | My Site — Page 2"
 ```
 
-### Meta Validators
+### Rate Limiting
 
 ```ts
-import { validateTitle, validateMetaDescription, calculatePixelWidth } from '@power-seo/core';
+import { createTokenBucket, consumeToken, getWaitTime, sleep } from '@power-seo/core';
 
-validateTitle('My Page Title');
-// { valid: true, length: 14, pixelWidth: 95, warnings: [] }
+const bucket = createTokenBucket(60); // 60 requests per minute
 
-validateMetaDescription('A description of the page content for search engines.');
-// { valid: true, length: 53, pixelWidth: 340, warnings: [] }
-
-calculatePixelWidth('My Title'); // → 56
+async function callApi() {
+  if (!consumeToken(bucket)) {
+    const waitMs = getWaitTime(bucket);
+    await sleep(waitMs);
+  }
+  // make your rate-limited API call
+}
 ```
 
-### URL Utilities
+### Inside a CI Content Quality Gate
+
+Block deploys when keyword density or word count fail:
 
 ```ts
-import {
-  normalizeUrl,
-  toSlug,
-  stripTrackingParams,
-  ensureTrailingSlash,
-  removeTrailingSlash,
-  isAbsoluteUrl,
-  resolveCanonical,
-} from '@power-seo/core';
+import { calculateKeywordDensity, getTextStatistics } from '@power-seo/core';
 
-normalizeUrl('https://example.com/PATH?utm_source=x'); // → "https://example.com/path"
-toSlug('My Blog Post!'); // → "my-blog-post"
-stripTrackingParams('https://example.com?utm_source=google&page=1'); // → "https://example.com?page=1"
-ensureTrailingSlash('https://example.com/blog'); // → "https://example.com/blog/"
-removeTrailingSlash('https://example.com/blog/'); // → "https://example.com/blog"
-isAbsoluteUrl('https://example.com'); // → true
-isAbsoluteUrl('/relative/path'); // → false
+const stats = getTextStatistics(bodyHtml);
+const density = calculateKeywordDensity(keyphrase, bodyHtml);
+
+if (stats.wordCount < 300) {
+  console.error(`✗ Word count too low: ${stats.wordCount} (minimum 300)`);
+  process.exit(1);
+}
+
+if (density.density < 0.5 || density.density > 2.5) {
+  console.error(`✗ Keyword density out of range: ${density.density}% (target 0.5–2.5%)`);
+  process.exit(1);
+}
 ```
 
-### Text Statistics
-
-```ts
-import {
-  getTextStatistics,
-  stripHtml,
-  getWords,
-  getSentences,
-  countSyllables,
-} from '@power-seo/core';
-
-const stats = getTextStatistics(
-  '<h1>Hello</h1><p>This is a sample paragraph with several words.</p>',
-);
-// { wordCount: 9, sentenceCount: 1, paragraphCount: 1, syllableCount: 14, avgWordsPerSentence: 9 }
-
-stripHtml('<p>Hello <strong>world</strong></p>'); // → "Hello world"
-getWords('Hello world'); // → ["Hello", "world"]
-countSyllables('beautiful'); // → 3
-```
-
-### Keyword Density
-
-```ts
-import {
-  calculateKeywordDensity,
-  countKeywordOccurrences,
-  analyzeKeyphraseOccurrences,
-} from '@power-seo/core';
-
-calculateKeywordDensity('react seo is great for react apps', 'react'); // → 0.1667 (16.67%)
-countKeywordOccurrences('react seo is great for react apps', 'react'); // → 2
-
-const analysis = analyzeKeyphraseOccurrences(
-  'Best coffee shops in NYC. The coffee shops on Fifth Avenue are particularly good.',
-  'coffee shops',
-);
-// { count: 2, density: 0.1538, positions: [1, 7], distribution: 'good' }
-```
-
-### Constants
-
-```ts
-import {
-  TITLE_MAX_LENGTH,
-  META_DESCRIPTION_MAX_LENGTH,
-  OG_IMAGE,
-  KEYWORD_DENSITY,
-  READABILITY,
-} from '@power-seo/core';
-
-TITLE_MAX_LENGTH; // 60
-META_DESCRIPTION_MAX_LENGTH; // 158
-OG_IMAGE.MIN_WIDTH; // 1200
-OG_IMAGE.MIN_HEIGHT; // 630
-KEYWORD_DENSITY.MIN; // 0.005 (0.5%)
-KEYWORD_DENSITY.MAX; // 0.03  (3%)
-```
+---
 
 ## API Reference
 
-### Meta Builders
+### Entry Points
 
-| Function             | Signature                                      | Description                                      |
-| -------------------- | ---------------------------------------------- | ------------------------------------------------ |
-| `buildMetaTags`      | `(config: MetaConfig) => MetaTag[]`            | Generate meta tag objects from SEO config        |
-| `buildLinkTags`      | `(config: LinkConfig) => LinkTag[]`            | Generate link tag objects (canonical, alternate) |
-| `buildOpenGraphTags` | `(config: OpenGraphConfig) => MetaTag[]`       | Generate Open Graph `og:*` meta tags             |
-| `buildTwitterTags`   | `(config: TwitterConfig) => MetaTag[]`         | Generate Twitter Card `twitter:*` meta tags      |
-| `buildHreflangTags`  | `(entries: HreflangEntry[]) => LinkTag[]`      | Generate hreflang `<link rel="alternate">` tags  |
-| `resolveTitle`       | `(title: string, template?: string) => string` | Resolve title with optional template             |
+| Import | Description |
+| --- | --- |
+| `@power-seo/core` | All utilities, types, constants, builders, and validators |
 
-### Robots
+### Meta Builder Functions
 
-| Function             | Signature                                | Description                                |
-| -------------------- | ---------------------------------------- | ------------------------------------------ |
-| `buildRobotsContent` | `(directive: RobotsDirective) => string` | Build robots meta content string           |
-| `parseRobotsContent` | `(content: string) => RobotsDirective`   | Parse robots string into `RobotsDirective` |
+| Function | Description |
+| --- | --- |
+| `buildMetaTags(config)` | Build `MetaTag[]` array from `SEOConfig` |
+| `buildLinkTags(config)` | Build `LinkTag[]` including canonical and hreflang |
+| `buildOpenGraphTags(og)` | Build Open Graph `MetaTag[]` from `OpenGraphConfig` |
+| `buildTwitterTags(twitter)` | Build Twitter Card `MetaTag[]` from `TwitterCardConfig` |
+| `buildHreflangTags(alternates)` | Build hreflang `LinkTag[]` from `HreflangConfig[]` |
+| `resolveTitle(config)` | Resolve final title applying template if set |
 
-### Title
+### Meta Validator Functions
 
-| Function              | Signature                                          | Description                    |
-| --------------------- | -------------------------------------------------- | ------------------------------ |
-| `applyTitleTemplate`  | `(title: string, template: string) => string`      | Apply `%s` template to title   |
-| `createTitleTemplate` | `(options: TitleTemplateOptions) => TitleTemplate` | Create reusable title template |
+| Function | Description |
+| --- | --- |
+| `validateTitle(title)` | Validate title — char count, pixel width, severity |
+| `validateMetaDescription(desc)` | Validate meta description — char count, pixel width, severity |
+| `calculatePixelWidth(text)` | Calculate SERP pixel width using Arial font metrics |
 
-### Validators
+### URL Utility Functions
 
-| Function                  | Signature                                   | Description                                                |
-| ------------------------- | ------------------------------------------- | ---------------------------------------------------------- |
-| `validateTitle`           | `(title: string) => ValidationResult`       | Validate title length and pixel width                      |
-| `validateMetaDescription` | `(description: string) => ValidationResult` | Validate description length and pixel width                |
-| `calculatePixelWidth`     | `(text: string) => number`                  | Calculate pixel width using Google's character width table |
+| Function | Description |
+| --- | --- |
+| `resolveCanonical(base, path?)` | Resolve and normalize a canonical URL |
+| `normalizeUrl(url)` | Remove default ports, double slashes, trailing slashes |
+| `ensureTrailingSlash(url)` | Add trailing slash to non-file URLs |
+| `removeTrailingSlash(url)` | Strip trailing slash from a URL |
+| `stripQueryParams(url, keep?)` | Remove all or selected query parameters |
+| `stripTrackingParams(url)` | Remove UTM, fbclid, gclid, and other tracking params |
+| `extractSlug(url)` | Extract the last path segment as a slug |
+| `isAbsoluteUrl(url)` | Check whether a URL is absolute |
+| `toSlug(text)` | Convert any string to a URL-safe slug |
 
-### URL Utilities
+### Text Statistics Functions
 
-| Function              | Signature                               | Description                                      |
-| --------------------- | --------------------------------------- | ------------------------------------------------ |
-| `resolveCanonical`    | `(url: string, base: string) => string` | Resolve canonical URL against base               |
-| `normalizeUrl`        | `(url: string) => string`               | Normalize URL (lowercase, remove trailing slash) |
-| `ensureTrailingSlash` | `(url: string) => string`               | Add trailing slash if missing                    |
-| `removeTrailingSlash` | `(url: string) => string`               | Remove trailing slash if present                 |
-| `stripQueryParams`    | `(url: string) => string`               | Remove all query parameters                      |
-| `stripTrackingParams` | `(url: string) => string`               | Remove UTM and tracking parameters only          |
-| `isAbsoluteUrl`       | `(url: string) => boolean`              | Check if URL is absolute                         |
-| `toSlug`              | `(text: string) => string`              | Convert text to URL-safe slug                    |
+| Function | Description |
+| --- | --- |
+| `getTextStatistics(content)` | Full stats — word, sentence, paragraph, syllable counts |
+| `stripHtml(html)` | Strip HTML tags, decode entities, return plain text |
+| `getWords(text)` | Split text into individual words |
+| `getSentences(text)` | Split text into sentences |
+| `getParagraphs(html)` | Extract paragraph blocks from HTML |
+| `countSyllables(word)` | Count syllables in a single word |
+| `countTotalSyllables(text)` | Count total syllables across all words in text |
 
-### Text Statistics
+### Keyword Density Functions
 
-| Function            | Signature                          | Description                             |
-| ------------------- | ---------------------------------- | --------------------------------------- |
-| `getTextStatistics` | `(html: string) => TextStatistics` | Comprehensive text statistics from HTML |
-| `stripHtml`         | `(html: string) => string`         | Remove HTML tags                        |
-| `getWords`          | `(text: string) => string[]`       | Split into words array                  |
-| `getSentences`      | `(text: string) => string[]`       | Split into sentences array              |
-| `getParagraphs`     | `(text: string) => string[]`       | Split into paragraphs array             |
-| `countSyllables`    | `(word: string) => number`         | Count syllables in a single word        |
+| Function | Description |
+| --- | --- |
+| `calculateKeywordDensity(keyword, content)` | Density %, occurrence count, word total |
+| `countKeywordOccurrences(text, keyword)` | Count keyword occurrences (case-insensitive, word-boundary) |
+| `analyzeKeyphraseOccurrences(config)` | Full occurrence map — title, H1, meta, slug, alt text |
 
-### Keyword Analysis
+### Robots Builder Functions
 
-| Function                      | Signature                                                | Description                            |
-| ----------------------------- | -------------------------------------------------------- | -------------------------------------- |
-| `calculateKeywordDensity`     | `(text: string, keyword: string) => number`              | Keyword density as decimal (0.05 = 5%) |
-| `countKeywordOccurrences`     | `(text: string, keyword: string) => number`              | Raw occurrence count                   |
-| `analyzeKeyphraseOccurrences` | `(text: string, keyphrase: string) => KeyphraseAnalysis` | Detailed keyphrase analysis            |
+| Function | Description |
+| --- | --- |
+| `buildRobotsContent(directive)` | Serialize `RobotsDirective` to robots meta content string |
+| `parseRobotsContent(content)` | Parse robots meta content string to `RobotsDirective` |
 
-### Core Types
+### Title Template Functions
 
-| Type               | Description                                                                                                                |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `MetaTag`          | `{ name?: string; property?: string; content: string; httpEquiv?: string }`                                                |
-| `LinkTag`          | `{ rel: string; href: string; hrefLang?: string; type?: string }`                                                          |
-| `RobotsDirective`  | Full robots directive configuration object                                                                                 |
-| `MetaConfig`       | Input config for `buildMetaTags()`                                                                                         |
-| `OpenGraphConfig`  | Input config for `buildOpenGraphTags()`                                                                                    |
-| `TwitterConfig`    | Input config for `buildTwitterTags()`                                                                                      |
-| `ValidationResult` | `{ valid: boolean; length: number; pixelWidth: number; warnings: string[] }`                                               |
-| `TextStatistics`   | `{ wordCount: number; sentenceCount: number; paragraphCount: number; syllableCount: number; avgWordsPerSentence: number }` |
+| Function | Description |
+| --- | --- |
+| `applyTitleTemplate(template, vars)` | Apply `%variable%` substitution to a title template |
+| `createTitleTemplate(defaults)` | Create a reusable title factory with site-wide defaults |
+
+### Rate Limiting Functions
+
+| Function | Description |
+| --- | --- |
+| `createTokenBucket(requestsPerMinute)` | Create a token bucket with capacity and refill rate |
+| `consumeToken(bucket)` | Consume one token; returns `true` if allowed |
+| `getWaitTime(bucket)` | Milliseconds to wait before next allowed request |
+| `sleep(ms)` | Promise-based sleep utility |
+
+### Constants
+
+| Constant | Value | Description |
+| --- | --- | --- |
+| `TITLE_MAX_PIXELS` | `580` | Google SERP max title display width (pixels) |
+| `TITLE_MAX_LENGTH` | `60` | Recommended max title character length |
+| `TITLE_MIN_LENGTH` | `50` | Recommended min title character length |
+| `META_DESCRIPTION_MAX_PIXELS` | `920` | Google SERP max meta description width (pixels) |
+| `META_DESCRIPTION_MAX_LENGTH` | `160` | Recommended max meta description length |
+| `META_DESCRIPTION_MIN_LENGTH` | `120` | Recommended min meta description length |
+| `MIN_WORD_COUNT` | `300` | Minimum word count to avoid thin content |
+| `RECOMMENDED_WORD_COUNT` | `1000` | Recommended word count for blog posts |
+| `MAX_URL_LENGTH` | `75` | Maximum recommended URL length for SEO |
+| `KEYWORD_DENSITY` | `{ MIN: 0.5, MAX: 2.5, OPTIMAL: 1.5 }` | Optimal keyword density range (%) |
+| `READABILITY` | `{ FLESCH_EASE_GOOD: 60, MAX_SENTENCE_LENGTH: 20, ... }` | Readability scoring thresholds |
+| `OG_IMAGE` | `{ WIDTH: 1200, HEIGHT: 630, ASPECT_RATIO: 1.91 }` | Open Graph recommended image dimensions |
+| `TWITTER_IMAGE` | `{ SUMMARY: { WIDTH: 144, HEIGHT: 144 }, SUMMARY_LARGE: { WIDTH: 800, HEIGHT: 418 } }` | Twitter Card recommended image dimensions |
+| `AI_CRAWLERS` | `['GPTBot', 'ClaudeBot', 'CCBot', ...]` | Common AI crawler user agents |
+| `SCHEMA_TYPES` | `['Article', 'Product', 'FAQPage', ...]` | Common Schema.org types used in SEO |
+
+### Types
+
+| Type | Description |
+| --- | --- |
+| `SEOConfig` | Full SEO configuration with title, meta, robots, OG, Twitter |
+| `MetaTag` | `{ name?, property?, httpEquiv?, content }` |
+| `LinkTag` | `{ rel, href, hreflang?, type?, sizes?, media? }` |
+| `OpenGraphConfig` | OG configuration with type, images, videos, article, profile |
+| `OpenGraphType` | `'website' \| 'article' \| 'book' \| 'profile' \| 'product' \| ...` |
+| `OpenGraphImage` | `{ url, secureUrl?, type?, width?, height?, alt? }` |
+| `TwitterCardConfig` | Twitter Card with card type, site, image, player, app |
+| `TwitterCardType` | `'summary' \| 'summary_large_image' \| 'app' \| 'player'` |
+| `RobotsDirective` | `{ index?, follow?, noarchive?, maxSnippet?, maxImagePreview?, ... }` |
+| `HreflangConfig` | `{ hrefLang, href }` |
+| `ContentAnalysisInput` | Input for content analysis — title, meta, content, keyphrase |
+| `ContentAnalysisOutput` | Output with score, maxScore, results, recommendations |
+| `AnalysisResult` | `{ id, title, description, status, score, maxScore }` |
+| `AnalysisStatus` | `'good' \| 'ok' \| 'poor'` |
+| `ReadabilityInput` | `{ content, locale? }` |
+| `ReadabilityOutput` | Flesch scores, passive voice %, transition word % |
+| `TextStatistics` | `{ wordCount, sentenceCount, paragraphCount, syllableCount, characterCount, ... }` |
+| `SitemapURL` | `{ loc, lastmod?, changefreq?, priority?, images?, videos?, news? }` |
+| `SitemapConfig` | `{ hostname, urls, maxUrlsPerSitemap?, outputDir? }` |
+| `RedirectRule` | `{ source, destination, statusCode, isRegex? }` |
+| `SchemaBase` | `{ '@context'?, '@type', '@id'?, [key]: unknown }` |
+| `SchemaGraphConfig` | `{ '@context': 'https://schema.org', '@graph': SchemaBase[] }` |
+| `KeywordDensityResult` | `{ keyword, count, density, totalWords }` |
+| `KeyphraseOccurrences` | Full occurrence map — title, H1, meta, slug, alt text, density |
+| `TokenBucket` | `{ tokens, lastRefill, maxTokens, refillRate }` |
+| `ValidationResult` | `{ valid, severity, message, charCount?, pixelWidth? }` |
+| `ValidationSeverity` | `'error' \| 'warning' \| 'info'` |
+| `TitleTemplateVars` | `{ title?, siteName?, separator?, tagline?, page?, [key]: string \| number }` |
+
+---
+
+## Use Cases
+
+- **@power-seo packages** — all 17 packages use `@power-seo/core` as a peer dependency for shared types, constants, and utilities
+- **Custom SEO libraries** — build your own SEO tooling on top of core's typed primitives without starting from scratch
+- **Next.js / Remix apps** — use `buildMetaTags()` and `buildLinkTags()` server-side in route handlers or layout components
+- **Content editors** — validate title and meta description SERP pixel widths in real time before publishing
+- **CI content quality gates** — check keyword density and word count programmatically in build pipelines
+- **eCommerce product pages** — validate product titles, descriptions, and slug quality at scale
+- **Rate-limited API integrations** — use the token bucket to respect rate limits for Google Search Console, Semrush, or Ahrefs APIs
+- **Headless CMS plugins** — use `analyzeKeyphraseOccurrences()` to show Yoast-style keyphrase feedback to editors
+
+---
+
+## Architecture Overview
+
+- **Pure TypeScript** — no compiled binary, no native modules
+- **Zero runtime dependencies** — ships clean with nothing else to install
+- **Framework-agnostic** — works in any JavaScript environment with no assumptions about React, Vue, or any framework
+- **SSR compatible** — safe to run in Next.js Server Components, Remix loaders, or Express handlers
+- **Edge runtime safe** — no Node.js-specific APIs; runs in Cloudflare Workers, Vercel Edge, Deno Deploy
+- **Tree-shakeable** — `"sideEffects": false` with named exports per module; import only what you use
+- **Dual ESM + CJS** — ships both formats via tsup for any bundler or `require()` usage
+
+---
+
+## Supply Chain Security
+
+- No install scripts (`postinstall`, `preinstall`)
+- No runtime network access
+- No `eval` or dynamic code execution
+- npm provenance enabled — every release is signed via Sigstore through GitHub Actions
+- CI-signed builds — all releases published via verified `github.com/CyberCraftBD/power-seo` workflow
+- Safe for SSR, Edge, and server environments
 
 ---
 
@@ -348,37 +483,41 @@ KEYWORD_DENSITY.MAX; // 0.03  (3%)
 
 All 17 packages are independently installable — use only what you need.
 
-| Package                                                                                    | Install                             | Description                                                                |
-| ------------------------------------------------------------------------------------------ | ----------------------------------- | -------------------------------------------------------------------------- |
-| [`@power-seo/core`](https://www.npmjs.com/package/@power-seo/core)                         | `npm i @power-seo/core`             | Framework-agnostic utilities, types, validators, and constants             |
-| [`@power-seo/react`](https://www.npmjs.com/package/@power-seo/react)                       | `npm i @power-seo/react`            | React SEO components — meta, Open Graph, Twitter Card, robots, breadcrumbs |
-| [`@power-seo/meta`](https://www.npmjs.com/package/@power-seo/meta)                         | `npm i @power-seo/meta`             | SSR meta helpers for Next.js App Router, Remix v2, and generic SSR         |
-| [`@power-seo/schema`](https://www.npmjs.com/package/@power-seo/schema)                     | `npm i @power-seo/schema`           | Type-safe JSON-LD structured data — 20 builders + 18 React components      |
-| [`@power-seo/content-analysis`](https://www.npmjs.com/package/@power-seo/content-analysis) | `npm i @power-seo/content-analysis` | Yoast-style SEO content scoring engine with React components               |
-| [`@power-seo/readability`](https://www.npmjs.com/package/@power-seo/readability)           | `npm i @power-seo/readability`      | Readability scoring — Flesch-Kincaid, Gunning Fog, Coleman-Liau, ARI       |
-| [`@power-seo/preview`](https://www.npmjs.com/package/@power-seo/preview)                   | `npm i @power-seo/preview`          | SERP, Open Graph, and Twitter/X Card preview generators                    |
-| [`@power-seo/sitemap`](https://www.npmjs.com/package/@power-seo/sitemap)                   | `npm i @power-seo/sitemap`          | XML sitemap generation, streaming, index splitting, and validation         |
-| [`@power-seo/redirects`](https://www.npmjs.com/package/@power-seo/redirects)               | `npm i @power-seo/redirects`        | Redirect engine with Next.js, Remix, and Express adapters                  |
-| [`@power-seo/links`](https://www.npmjs.com/package/@power-seo/links)                       | `npm i @power-seo/links`            | Link graph analysis — orphan detection, suggestions, equity scoring        |
-| [`@power-seo/audit`](https://www.npmjs.com/package/@power-seo/audit)                       | `npm i @power-seo/audit`            | Full SEO audit engine — meta, content, structure, performance rules        |
-| [`@power-seo/images`](https://www.npmjs.com/package/@power-seo/images)                     | `npm i @power-seo/images`           | Image SEO — alt text, lazy loading, format analysis, image sitemaps        |
-| [`@power-seo/ai`](https://www.npmjs.com/package/@power-seo/ai)                             | `npm i @power-seo/ai`               | LLM-agnostic AI prompt templates and parsers for SEO tasks                 |
-| [`@power-seo/analytics`](https://www.npmjs.com/package/@power-seo/analytics)               | `npm i @power-seo/analytics`        | Merge GSC + audit data, trend analysis, ranking insights, dashboard        |
-| [`@power-seo/search-console`](https://www.npmjs.com/package/@power-seo/search-console)     | `npm i @power-seo/search-console`   | Google Search Console API — OAuth2, service account, URL inspection        |
-| [`@power-seo/integrations`](https://www.npmjs.com/package/@power-seo/integrations)         | `npm i @power-seo/integrations`     | Semrush and Ahrefs API clients with rate limiting and pagination           |
-| [`@power-seo/tracking`](https://www.npmjs.com/package/@power-seo/tracking)                 | `npm i @power-seo/tracking`         | GA4, Clarity, PostHog, Plausible, Fathom — scripts + consent management    |
+| Package                                                                                    | Install                             | Description                                                             |
+| ------------------------------------------------------------------------------------------ | ----------------------------------- | ----------------------------------------------------------------------- |
+| [`@power-seo/core`](https://www.npmjs.com/package/@power-seo/core)                         | `npm i @power-seo/core`             | Framework-agnostic utilities, types, validators, and constants          |
+| [`@power-seo/react`](https://www.npmjs.com/package/@power-seo/react)                       | `npm i @power-seo/react`            | React SEO components — meta, Open Graph, Twitter Card, breadcrumbs      |
+| [`@power-seo/meta`](https://www.npmjs.com/package/@power-seo/meta)                         | `npm i @power-seo/meta`             | SSR meta helpers for Next.js App Router, Remix v2, and generic SSR      |
+| [`@power-seo/schema`](https://www.npmjs.com/package/@power-seo/schema)                     | `npm i @power-seo/schema`           | Type-safe JSON-LD structured data — 20 builders + 18 React components   |
+| [`@power-seo/content-analysis`](https://www.npmjs.com/package/@power-seo/content-analysis) | `npm i @power-seo/content-analysis` | Yoast-style SEO content scoring engine with React components            |
+| [`@power-seo/readability`](https://www.npmjs.com/package/@power-seo/readability)           | `npm i @power-seo/readability`      | Readability scoring — Flesch-Kincaid, Gunning Fog, Coleman-Liau, ARI    |
+| [`@power-seo/preview`](https://www.npmjs.com/package/@power-seo/preview)                   | `npm i @power-seo/preview`          | SERP, Open Graph, and Twitter/X Card preview generators                 |
+| [`@power-seo/sitemap`](https://www.npmjs.com/package/@power-seo/sitemap)                   | `npm i @power-seo/sitemap`          | XML sitemap generation, streaming, index splitting, and validation      |
+| [`@power-seo/redirects`](https://www.npmjs.com/package/@power-seo/redirects)               | `npm i @power-seo/redirects`        | Redirect engine with Next.js, Remix, and Express adapters               |
+| [`@power-seo/links`](https://www.npmjs.com/package/@power-seo/links)                       | `npm i @power-seo/links`            | Link graph analysis — orphan detection, suggestions, equity scoring     |
+| [`@power-seo/audit`](https://www.npmjs.com/package/@power-seo/audit)                       | `npm i @power-seo/audit`            | Full SEO audit engine — meta, content, structure, performance rules     |
+| [`@power-seo/images`](https://www.npmjs.com/package/@power-seo/images)                     | `npm i @power-seo/images`           | Image SEO — alt text, lazy loading, format analysis, image sitemaps     |
+| [`@power-seo/ai`](https://www.npmjs.com/package/@power-seo/ai)                             | `npm i @power-seo/ai`               | LLM-agnostic AI prompt templates and parsers for SEO tasks              |
+| [`@power-seo/analytics`](https://www.npmjs.com/package/@power-seo/analytics)               | `npm i @power-seo/analytics`        | Merge GSC + audit data, trend analysis, ranking insights, dashboard     |
+| [`@power-seo/search-console`](https://www.npmjs.com/package/@power-seo/search-console)     | `npm i @power-seo/search-console`   | Google Search Console API — OAuth2, service account, URL inspection     |
+| [`@power-seo/integrations`](https://www.npmjs.com/package/@power-seo/integrations)         | `npm i @power-seo/integrations`     | Semrush and Ahrefs API clients with rate limiting and pagination        |
+| [`@power-seo/tracking`](https://www.npmjs.com/package/@power-seo/tracking)                 | `npm i @power-seo/tracking`         | GA4, Clarity, PostHog, Plausible, Fathom — scripts + consent management |
+
+---
+
+## Keywords
+
+seo utilities typescript · meta tag builder npm · pixel-accurate serp validator · keyword density calculator typescript · url normalization seo · canonical url builder · text statistics library · open graph meta tag builder · twitter card builder · hreflang link tag generator · robots directive builder · title template engine · seo primitives library · framework-agnostic seo utilities · token bucket rate limiter · seo types typescript · slug generator npm · html text extractor · nextjs seo utilities · seo constants npm · serp pixel width calculator · keyphrase occurrence analyzer · seo foundation package · shared seo types monorepo · seo utility functions typescript · meta description validator · structured data types typescript
 
 ---
 
 ## About [CyberCraft Bangladesh](https://ccbd.dev)
 
-**[CyberCraft Bangladesh](https://ccbd.dev)** is a Bangladesh-based enterprise-grade software engineering company specializing in ERP system development, AI-powered SaaS and business applications, full-stack SEO services, custom website development, and scalable eCommerce platforms. We design and develop intelligent, automation-driven SaaS and enterprise solutions that help startups, SMEs, NGOs, educational institutes, and large organizations streamline operations, enhance digital visibility, and accelerate growth through modern cloud-native technologies.
+**[CyberCraft Bangladesh](https://ccbd.dev)** is a Bangladesh-based enterprise-grade software development and Full Stack SEO service provider company specializing in ERP system development, AI-powered SaaS and business applications, full-stack SEO services, custom website development, and scalable eCommerce platforms. We design and develop intelligent, automation-driven SaaS and enterprise solutions that help startups, SMEs, NGOs, educational institutes, and large organizations streamline operations, enhance digital visibility, and accelerate growth through modern cloud-native technologies.
 
-|                      |                                                                |
-| -------------------- | -------------------------------------------------------------- |
-| **Website**          | [ccbd.dev](https://ccbd.dev)                                   |
-| **GitHub**           | [github.com/cybercraftbd](https://github.com/cybercraftbd)     |
-| **npm Organization** | [npmjs.com/org/power-seo](https://www.npmjs.com/org/power-seo) |
-| **Email**            | [info@ccbd.dev](mailto:info@ccbd.dev)                          |
+[![Website](https://img.shields.io/badge/Website-ccbd.dev-blue?style=for-the-badge)](https://ccbd.dev)
+[![GitHub](https://img.shields.io/badge/GitHub-cybercraftbd-black?style=for-the-badge&logo=github)](https://github.com/cybercraftbd)
+[![npm](https://img.shields.io/badge/npm-power--seo-red?style=for-the-badge&logo=npm)](https://www.npmjs.com/org/power-seo)
+[![Email](https://img.shields.io/badge/Email-info@ccbd.dev-green?style=for-the-badge&logo=gmail)](mailto:info@ccbd.dev)
 
 © 2026 [CyberCraft Bangladesh](https://ccbd.dev) · Released under the [MIT License](../../LICENSE)

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -9,7 +9,7 @@ export const TITLE_MAX_PIXELS = 580;
 export const TITLE_MAX_LENGTH = 60;
 
 /** Google SERP title minimum recommended character length */
-export const TITLE_MIN_LENGTH = 30;
+export const TITLE_MIN_LENGTH = 50;
 
 /** Google SERP meta description max display width in pixels (desktop) */
 export const META_DESCRIPTION_MAX_PIXELS = 920;

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
   minify: false,
 });

--- a/packages/images/tsup.config.ts
+++ b/packages/images/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
 });

--- a/packages/integrations/tsup.config.ts
+++ b/packages/integrations/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
 });

--- a/packages/links/tsup.config.ts
+++ b/packages/links/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
 });

--- a/packages/meta/tsup.config.ts
+++ b/packages/meta/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
 });

--- a/packages/preview/README.md
+++ b/packages/preview/README.md
@@ -1,71 +1,85 @@
-# @power-seo/preview — SERP, Open Graph & Twitter/X Card Preview Generators for TypeScript — Pixel-Accurate, Zero Dependencies
+# @power-seo/preview
+
+Pixel-accurate SERP, Open Graph, and Twitter/X Card preview generators for TypeScript — compute exactly how a page appears in Google search results and social shares without a headless browser or canvas.
 
 [![npm version](https://img.shields.io/npm/v/@power-seo/preview)](https://www.npmjs.com/package/@power-seo/preview)
 [![npm downloads](https://img.shields.io/npm/dm/@power-seo/preview)](https://www.npmjs.com/package/@power-seo/preview)
+[![Socket](https://socket.dev/api/badge/npm/package/@power-seo/preview)](https://socket.dev/npm/package/@power-seo/preview)
+[![npm provenance](https://img.shields.io/badge/npm-provenance-enabled-blue)](https://github.com/CyberCraftBD/power-seo/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
 [![tree-shakeable](https://img.shields.io/badge/tree--shakeable-yes-brightgreen)](https://bundlephobia.com/package/@power-seo/preview)
 
----
+`@power-seo/preview` delivers pixel-width-aware SERP snippet generation, Open Graph image validation, and Twitter/X Card preview data — comparable to what Yoast SEO, Semrush, and Moz Pro show in their browser-based UIs, but as a standalone TypeScript library that runs anywhere. Provide a title, meta description, URL, and optional OG image — get back structured preview data with truncation flags, breadcrumb paths, and image validation results. Run it server-side in a CMS pipeline, client-side in a React editor, or inside a CI content gate. All four generators are fully tree-shakeable.
 
-## Overview
-
-**@power-seo/preview** is a pixel-accurate preview generator for TypeScript developers and CMS platforms that helps you compute exactly how a page will appear in Google SERP, Open Graph social cards, and Twitter/X Cards — without a headless browser or canvas.
-
-**What it does**
-
-- ✅ **Generate Google SERP previews** — pixel-width-aware title and description truncation (600px / 920px)
-- ✅ **Generate Open Graph card previews** — image dimension validation, display title and domain
-- ✅ **Generate Twitter/X Card previews** — `summary` and `summary_large_image` card types with image validation
-- ✅ **Truncate at pixel width** — `truncateAtPixelWidth()` uses character width tables, not character counts
-- ✅ **Validate image constraints** — warns when OG images are too small, too large, or wrong aspect ratio
-
-**What it is not**
-
-- ❌ **Not a visual renderer** — returns structured data, not HTML or screenshots
-- ❌ **Not a headless browser** — no Puppeteer, no canvas, no DOM required
-
-**Recommended for**
-
-- **CMS preview panels**, **SEO auditing tools**, **Next.js / Remix content editors**, and **programmatic SEO pipelines**
+> **Zero runtime dependencies** — only `@power-seo/core` as a peer.
 
 ---
 
-## Why @power-seo/preview Matters
+## Why @power-seo/preview?
 
-**The problem**
-
-- **SERP truncation is pixel-based**, not character-based — a title with wide characters (W, M) can overflow at fewer chars than one with narrow characters (i, l)
-- **OG images are rejected silently** — Facebook and LinkedIn drop cards for under-sized images with no visible warning
-- **Twitter Card specs differ from OG** — card type, image ratio requirements, and display text limits vary
-
-**Why developers care**
-
-- **Performance:** Correct SERP snippets increase click-through rates
-- **SEO:** OG cards with valid image dimensions drive social traffic
-- **UX:** Preview-as-you-type in CMS reduces publish-and-regret cycles
+| | Without | With |
+|---|---|---|
+| SERP title truncation | ❌ Guesswork (character count) | ✅ Pixel-accurate truncation at 580px |
+| SERP description truncation | ❌ Unchecked | ✅ Pixel-accurate truncation at 920px |
+| OG image validation | ❌ Silent drop by Facebook/LinkedIn | ✅ Dimension check with pass/fail message |
+| Twitter/X Card preview | ❌ Manual spec lookup | ✅ `summary` + `summary_large_image` with image validation |
+| breadcrumb path | ❌ Unknown | ✅ Google-style `example.com › blog › post` format |
+| React preview components | ❌ Build from scratch | ✅ Drop-in `SerpPreview`, `OgPreview`, `TwitterPreview`, `PreviewPanel` |
+| Framework support | ❌ Browser tools only | ✅ Next.js, Remix, Node.js, Edge, any JS environment |
 
 ---
 
-## Key Features
+## Features
 
-- **Pixel-accurate SERP truncation** — `generateSerpPreview()` truncates title at 600px, description at 920px using character width lookup tables
-- **Open Graph card validation** — `generateOgPreview()` validates 1200×630 recommended dimensions and reports warnings
-- **Twitter/X Card support** — `generateTwitterPreview()` handles both `summary` and `summary_large_image` card types
-- **Low-level truncation primitive** — `truncateAtPixelWidth()` for truncating arbitrary strings at any pixel budget
-- **Structured output** — returns typed data objects ready for your own UI, not HTML strings
-- **Type-safe API** — TypeScript-first with full `.d.ts` declarations for all inputs, outputs, and validation results
-- **Tree-shakeable** — import only the preview generators you use
+- **Pixel-accurate SERP truncation** — `generateSerpPreview()` truncates title at 580px, description at 920px using character-width lookup tables
+- **Site title composition** — optional `siteTitle` field appended as `"title - siteTitle"` before truncation, matching Google's display format
+- **Google breadcrumb URL** — formats `https://example.com/blog/my-post` as `example.com › blog › my-post`
+- **Open Graph image validation** — `generateOgPreview()` validates image dimensions against the recommended 1200×630 minimum and reports pass/fail with a message
+- **Twitter/X Card support** — `generateTwitterPreview()` handles `summary` and `summary_large_image` card types with per-type image dimension requirements
+- **Low-level truncation primitive** — `truncateAtPixelWidth()` truncates any string at any pixel budget, usable independently of the preview generators
+- **Structured typed output** — returns plain data objects ready for any UI renderer; no HTML, no DOM required
+- **React UI components** — pre-built `SerpPreview`, `OgPreview`, `TwitterPreview`, and `PreviewPanel` from the `/react` subpath
+- **Framework-agnostic** — works in Next.js, Remix, Gatsby, Vite, vanilla Node.js, Edge
+- **Full TypeScript support** — complete type definitions for all inputs, outputs, and validation results
+- **Tree-shakeable** — import only the generators you use; `"sideEffects": false`
 - **Zero runtime dependencies** — pure computation, no canvas, no browser, no external libraries
 
 ---
 
-## Benefits of Using @power-seo/preview
+## Comparison
 
-- **Improved CTR**: Correctly sized SERP titles eliminate mid-word truncation that confuses searchers
-- **Better social sharing**: OG image validation catches under-sized images before they silently drop social cards
-- **Safer content editing**: CMS authors see pixel-accurate previews before publishing, not after
-- **Faster delivery**: No browser spin-up; preview computation is synchronous and instant
+| Feature | @power-seo/preview | Yoast SEO | next-seo | react-helmet | seo-analyzer |
+| --- | :---: | :---: | :---: | :---: | :---: |
+| Pixel-accurate SERP truncation | ✅ | ✅ (browser only) | ❌ | ❌ | ❌ |
+| SERP description truncation | ✅ | ✅ (browser only) | ❌ | ❌ | ❌ |
+| Google breadcrumb URL format | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Open Graph image validation | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Twitter/X Card preview generation | ✅ | ❌ | ❌ | ❌ | ❌ |
+| React preview components | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Works outside WordPress | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Edge runtime safe | ✅ | ❌ | ✅ | ✅ | ❌ |
+| Structured data output (not HTML) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| TypeScript-first | ✅ | ❌ | Partial | ❌ | ❌ |
+| Tree-shakeable | ✅ | ❌ | Partial | ❌ | ❌ |
+| CI / Node.js usage | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Zero runtime dependencies | ✅ | ❌ | ❌ | ❌ | ❌ |
+
+---
+
+## Installation
+
+```bash
+npm install @power-seo/preview
+```
+
+```bash
+yarn add @power-seo/preview
+```
+
+```bash
+pnpm add @power-seo/preview
+```
 
 ---
 
@@ -74,19 +88,17 @@
 ```ts
 import { generateSerpPreview, generateOgPreview } from '@power-seo/preview';
 
-// Google SERP snippet
 const serp = generateSerpPreview({
-  title: 'How to Add SEO to React Apps — Complete Guide',
-  description:
-    'Learn how to add meta tags, Open Graph, Twitter Cards, and JSON-LD structured data to any React application.',
+  title: 'How to Add SEO to React Apps',
+  description: 'Learn how to add meta tags, Open Graph, and JSON-LD to any React application.',
   url: 'https://example.com/blog/react-seo',
+  siteTitle: 'My Blog',  // optional — appended as "title - siteTitle"
 });
 
-console.log(serp.title.display); // truncated title (≤600px)
-console.log(serp.description.display); // truncated description (≤920px)
-console.log(serp.breadcrumb); // 'example.com › blog › react-seo'
+console.log(serp.title);            // 'How to Add SEO to React Apps - My Blog' (truncated at 580px if too long)
+console.log(serp.displayUrl);       // 'example.com › blog › react-seo'
+console.log(serp.titleTruncated);   // false
 
-// Open Graph card
 const og = generateOgPreview({
   title: 'React SEO Guide',
   description: 'Complete SEO for React',
@@ -94,298 +106,422 @@ const og = generateOgPreview({
   image: { url: 'https://example.com/og.jpg', width: 1200, height: 630 },
 });
 
-console.log(og.image.validation.valid); // true
-```
-
-**What you should see**
-
-- `serp.title.isTruncated` — `false` if title fits within 600px pixel budget
-- `og.image.validation.warnings` — empty array if dimensions meet OG recommendations
-
----
-
-## Installation
-
-```bash
-npm i @power-seo/preview
-# or
-yarn add @power-seo/preview
-# or
-pnpm add @power-seo/preview
-# or
-bun add @power-seo/preview
+console.log(og.image?.valid);    // true
+console.log(og.image?.message);  // undefined (dimensions are correct)
 ```
 
 ---
 
-## Framework Compatibility
+## Usage
 
-**Supported**
+### Generating a Google SERP Preview
 
-- ✅ Next.js (App Router / Pages Router) — use in server components, API routes, or `generateMetadata`
-- ✅ Remix — use in loaders or action functions
-- ✅ Node.js 18+ — pure module, no native bindings
-- ✅ Edge runtimes — no Node.js-specific APIs
-- ✅ React (optional peer dep) — `/react` subpath export for React components
+`generateSerpPreview()` computes the display title, breadcrumb URL, and description that Google would show, with pixel-accurate truncation flags.
 
-**Environment notes**
+```ts
+import { generateSerpPreview } from '@power-seo/preview';
 
-- **SSR/SSG:** Fully supported — computation is synchronous
-- **Edge runtime:** Supported — no `fs`, no `canvas`, no browser APIs
-- **Browser-only usage:** Supported — works in any browser JS environment
+const serp = generateSerpPreview({
+  title: 'Next.js SEO Best Practices',
+  description: 'Learn how to optimize your Next.js app for search engines with meta tags and structured data.',
+  url: 'https://example.com/nextjs-seo',
+  siteTitle: 'Dev Blog',  // optional
+});
 
----
-
-## Use Cases
-
-- **CMS live preview panels** — show authors how their title/description will appear in Google before publishing
-- **SEO auditing pipelines** — detect truncated titles and missing OG images at build time
-- **Programmatic SEO sites** — validate auto-generated titles for thousands of pages at once
-- **Social media schedulers** — validate OG image dimensions before queuing posts
-- **SaaS marketing dashboards** — show SERP/social preview for every page
-- **Blog platforms** — live preview as editors type the meta description
-- **E-commerce product pages** — ensure product image dimensions meet OG card requirements
-- **Landing page builders** — embed SERP and social card preview in the editor UI
-
----
-
-## Example (Before / After)
-
-```text
-Before (unchecked):
-- Title: "Buy Premium Running Shoes Online — Free Shipping Worldwide — RunFast Store"
-- Pixel width: ~720px → SERP shows "Buy Premium Running Shoes Online — Free Ship..."
-- OG image: 800×400 → too small, card dropped by Facebook
-
-After (@power-seo/preview):
-- title.isTruncated: true → author shortens to "Premium Running Shoes — Free Shipping | RunFast"
-- og.image.validation.warnings: ['Image width 800px is below recommended 1200px'] → author uploads 1200×630 image
-- Social card renders correctly on Facebook, LinkedIn, Twitter
+// serp.title            → 'Next.js SEO Best Practices - Dev Blog' (possibly truncated)
+// serp.displayUrl       → 'example.com › nextjs-seo'
+// serp.description      → display description (possibly truncated at 920px)
+// serp.titleTruncated   → true | false
+// serp.titleValidation  → ValidationResult from @power-seo/core
 ```
 
----
+### Generating an Open Graph Preview
 
-## Implementation Best Practices
+`generateOgPreview()` validates image dimensions and returns a structured card data object for Facebook, LinkedIn, and other OG-compatible platforms.
 
-- **Keep SERP titles under 550px** — gives a safety margin for varying render environments
-- **Target SERP descriptions at 800–900px** — Google may show more or less, but staying under 920px is safe
-- **Always use 1200×630 for OG images** — this is the safe standard for Facebook, LinkedIn, and WhatsApp
-- **Use `summary_large_image` for blog/article pages** — much higher engagement than `summary`
-- **Run `generateSerpPreview` in CI** — catch truncation regressions in auto-generated title templates
+```ts
+import { generateOgPreview } from '@power-seo/preview';
 
----
+const og = generateOgPreview({
+  title: 'React SEO Guide',
+  description: 'Complete guide to adding SEO in React apps.',
+  url: 'https://example.com/react-seo',
+  siteName: 'Dev Blog',
+  image: { url: 'https://example.com/og.jpg', width: 800, height: 400 },
+});
 
-## Architecture Overview
+// og.image?.valid    → false (too small)
+// og.image?.message  → 'Image is 800x400px. Minimum size is 200x200px.'
+```
 
-**Where it runs**
+### Generating a Twitter/X Card Preview
 
-- **Build-time**: Audit title/description pixel widths across all pages during static generation
-- **Runtime**: Power CMS live preview panels with real-time truncation feedback
-- **CI/CD**: Validate OG image dimensions and SERP titles in pull request checks
+`generateTwitterPreview()` handles both `summary` and `summary_large_image` card types, each with different image dimension requirements.
 
-**Data flow**
+```ts
+import { generateTwitterPreview } from '@power-seo/preview';
 
-1. **Input**: Page title, meta description, URL, OG image metadata
-2. **Analysis**: Character-width table lookup → pixel budget comparison → image dimension validation
-3. **Output**: Structured `SerpPreviewData`, `OgPreviewData`, `TwitterPreviewData` objects with `isTruncated`, `warnings`
-4. **Action**: CMS shows preview, CI fails on truncation, author updates content
+const twitter = generateTwitterPreview({
+  cardType: 'summary_large_image',
+  title: 'React SEO Guide',
+  description: 'Everything you need to add SEO to any React application.',
+  url: 'https://example.com/react-seo',
+  site: '@myblog',
+  image: { url: 'https://example.com/twitter.jpg', width: 1200, height: 628 },
+});
 
----
+// twitter.cardType  → 'summary_large_image'
+// twitter.domain    → 'myblog'
+// twitter.image?.valid → true
+```
 
-## Features Comparison with Popular Packages
+### Using the Low-Level Truncation Primitive
 
-| Capability                        | next-seo | react-helmet |        yoast (WP) | @power-seo/preview |
-| --------------------------------- | -------: | -----------: | ----------------: | -----------------: |
-| Pixel-accurate SERP truncation    |       ❌ |           ❌ | ✅ (browser only) |                 ✅ |
-| OG image dimension validation     |       ❌ |           ❌ |                ❌ |                 ✅ |
-| Twitter/X Card preview generation |       ❌ |           ❌ |                ❌ |                 ✅ |
-| Zero runtime dependencies         |       ✅ |           ✅ |                ❌ |                 ✅ |
-| Works in edge runtimes            |       ✅ |           ✅ |                ❌ |                 ✅ |
-| Structured data output (not HTML) |       ❌ |           ❌ |                ❌ |                 ✅ |
+`truncateAtPixelWidth()` is a standalone utility — use it to truncate any string at any pixel budget, independent of the SERP generator.
 
----
+```ts
+import { truncateAtPixelWidth } from '@power-seo/preview';
 
-## [@power-seo](https://www.npmjs.com/org/power-seo) Ecosystem
+const result = truncateAtPixelWidth('Buy Premium Running Shoes Online — Free Shipping Worldwide', 580);
 
-All 17 packages are independently installable — use only what you need.
+// result.text      → 'Buy Premium Running Shoes Online — Free Shippi...'
+// result.truncated → true
+```
 
-| Package                                                                                    | Install                             | Description                                                             |
-| ------------------------------------------------------------------------------------------ | ----------------------------------- | ----------------------------------------------------------------------- |
-| [`@power-seo/core`](https://www.npmjs.com/package/@power-seo/core)                         | `npm i @power-seo/core`             | Framework-agnostic utilities, types, validators, and constants          |
-| [`@power-seo/react`](https://www.npmjs.com/package/@power-seo/react)                       | `npm i @power-seo/react`            | React SEO components — meta, Open Graph, Twitter Card, breadcrumbs      |
-| [`@power-seo/meta`](https://www.npmjs.com/package/@power-seo/meta)                         | `npm i @power-seo/meta`             | SSR meta helpers for Next.js App Router, Remix v2, and generic SSR      |
-| [`@power-seo/schema`](https://www.npmjs.com/package/@power-seo/schema)                     | `npm i @power-seo/schema`           | Type-safe JSON-LD structured data — 20 builders + 18 React components   |
-| [`@power-seo/content-analysis`](https://www.npmjs.com/package/@power-seo/content-analysis) | `npm i @power-seo/content-analysis` | Yoast-style SEO content scoring engine with React components            |
-| [`@power-seo/readability`](https://www.npmjs.com/package/@power-seo/readability)           | `npm i @power-seo/readability`      | Readability scoring — Flesch-Kincaid, Gunning Fog, Coleman-Liau, ARI    |
-| [`@power-seo/preview`](https://www.npmjs.com/package/@power-seo/preview)                   | `npm i @power-seo/preview`          | SERP, Open Graph, and Twitter/X Card preview generators                 |
-| [`@power-seo/sitemap`](https://www.npmjs.com/package/@power-seo/sitemap)                   | `npm i @power-seo/sitemap`          | XML sitemap generation, streaming, index splitting, and validation      |
-| [`@power-seo/redirects`](https://www.npmjs.com/package/@power-seo/redirects)               | `npm i @power-seo/redirects`        | Redirect engine with Next.js, Remix, and Express adapters               |
-| [`@power-seo/links`](https://www.npmjs.com/package/@power-seo/links)                       | `npm i @power-seo/links`            | Link graph analysis — orphan detection, suggestions, equity scoring     |
-| [`@power-seo/audit`](https://www.npmjs.com/package/@power-seo/audit)                       | `npm i @power-seo/audit`            | Full SEO audit engine — meta, content, structure, performance rules     |
-| [`@power-seo/images`](https://www.npmjs.com/package/@power-seo/images)                     | `npm i @power-seo/images`           | Image SEO — alt text, lazy loading, format analysis, image sitemaps     |
-| [`@power-seo/ai`](https://www.npmjs.com/package/@power-seo/ai)                             | `npm i @power-seo/ai`               | LLM-agnostic AI prompt templates and parsers for SEO tasks              |
-| [`@power-seo/analytics`](https://www.npmjs.com/package/@power-seo/analytics)               | `npm i @power-seo/analytics`        | Merge GSC + audit data, trend analysis, ranking insights, dashboard     |
-| [`@power-seo/search-console`](https://www.npmjs.com/package/@power-seo/search-console)     | `npm i @power-seo/search-console`   | Google Search Console API — OAuth2, service account, URL inspection     |
-| [`@power-seo/integrations`](https://www.npmjs.com/package/@power-seo/integrations)         | `npm i @power-seo/integrations`     | Semrush and Ahrefs API clients with rate limiting and pagination        |
-| [`@power-seo/tracking`](https://www.npmjs.com/package/@power-seo/tracking)                 | `npm i @power-seo/tracking`         | GA4, Clarity, PostHog, Plausible, Fathom — scripts + consent management |
+### React Components
 
-### Ecosystem vs alternatives
+Import from the `/react` entry point for pre-built preview UI components:
 
-| Need            | Common approach                       | @power-seo approach                            |
-| --------------- | ------------------------------------- | ---------------------------------------------- |
-| SERP preview    | Browser-based tools (Moz, SEMrush UI) | `@power-seo/preview` — programmatic, zero dep  |
-| OG preview      | Manual checking on social debuggers   | `@power-seo/preview` — validate before publish |
-| Meta tags       | `next-seo` / `react-helmet`           | `@power-seo/meta` + `@power-seo/react`         |
-| Structured data | Manual JSON-LD                        | `@power-seo/schema` — typed builders           |
+```tsx
+import { SerpPreview, OgPreview, TwitterPreview, PreviewPanel } from '@power-seo/preview/react';
 
----
+// All-in-one tabbed panel (Google / Facebook / Twitter)
+function EditorSidebar() {
+  return (
+    <PreviewPanel
+      title="How to Add SEO to React Apps"
+      description="Learn meta tags, Open Graph, and JSON-LD for React."
+      url="https://example.com/blog/react-seo"
+      siteTitle="My Blog"
+      siteName="My Blog"
+      image={{ url: 'https://example.com/og.jpg', width: 1200, height: 630 }}
+      twitterCardType="summary_large_image"
+      twitterSite="@myblog"
+    />
+  );
+}
 
-## Enterprise Integration
+// Or use individual components
+function SerpCard() {
+  return (
+    <SerpPreview
+      title="How to Add SEO to React Apps"
+      description="Learn meta tags, Open Graph, and JSON-LD for React."
+      url="https://example.com/blog/react-seo"
+      siteTitle="My Blog"
+    />
+  );
+}
+```
 
-**Multi-tenant SaaS**
+### Inside a CI Content Quality Gate
 
-- **Tenant-aware validation**: Run `generateSerpPreview` per tenant's locale — pixel widths vary by character set
-- **Per-page audit pipelines**: Validate all auto-generated titles across thousands of product pages
-- **CMS integration**: Expose preview data via API endpoint; embed in editor sidebar
+Block deploys when SERP titles or OG images fail validation:
 
-**ERP / internal portals**
+```ts
+import { generateSerpPreview, generateOgPreview } from '@power-seo/preview';
 
-- Validate public-facing module titles for SERP appearance
-- Audit OG images for partner portal landing pages
-- Run preview checks as part of the content approval workflow
+const serp = generateSerpPreview({ title, description, url, siteTitle });
+const og = generateOgPreview({ title, description, url, image });
 
-**Recommended integration pattern**
+if (serp.titleTruncated) {
+  console.error('SERP title exceeds 580px — will be cut off in Google results');
+  process.exit(1);
+}
 
-- Run `generateSerpPreview` in **CI** on title template changes
-- Fail build when `isTruncated === true` on critical pages
-- Export validation results as **JSON artifacts** for content team review
-
----
-
-## Scope and Limitations
-
-**This package does**
-
-- ✅ Compute pixel-width-aware SERP title and description truncation
-- ✅ Validate OG image dimensions against recommended constraints
-- ✅ Generate Twitter/X Card preview data for both card types
-- ✅ Return structured data objects for rendering in any UI
-
-**This package does not**
-
-- ❌ Render visual HTML previews or screenshots
-- ❌ Fetch live pages from the internet
-- ❌ Submit content to search engines or social platforms
-- ❌ Guarantee Google's actual rendering behavior (which varies by search context)
+if (og.image && !og.image.valid) {
+  console.error('OG image invalid:', og.image.message);
+  process.exit(1);
+}
+```
 
 ---
 
 ## API Reference
 
-### `generateSerpPreview(input)`
+### Entry Points
+
+| Import | Description |
+| --- | --- |
+| `@power-seo/preview` | Core preview generators and truncation utility |
+| `@power-seo/preview/react` | React components for preview UI |
+
+### `generateSerpPreview()`
 
 ```ts
 function generateSerpPreview(input: SerpPreviewInput): SerpPreviewData;
 ```
 
-| Input Prop    | Type     | Description        |
-| ------------- | -------- | ------------------ |
-| `title`       | `string` | Page title         |
-| `description` | `string` | Meta description   |
-| `url`         | `string` | Canonical page URL |
+#### `SerpPreviewInput`
 
-| Output Field  | Type             | Description                                  |
-| ------------- | ---------------- | -------------------------------------------- |
-| `title`       | `TruncateResult` | Display title with truncation metadata       |
-| `description` | `TruncateResult` | Display description with truncation metadata |
-| `breadcrumb`  | `string`         | Breadcrumb path (e.g. `example.com › blog`)  |
-| `url`         | `string`         | Canonical URL                                |
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `title` | `string` | ✅ | Page title |
+| `description` | `string` | ✅ | Meta description |
+| `url` | `string` | ✅ | Canonical page URL |
+| `siteTitle` | `string` | — | Site name — appended as `"title - siteTitle"` before truncation |
+
+#### `SerpPreviewData`
+
+| Output Field | Type | Description |
+| --- | --- | --- |
+| `title` | `string` | Display title (truncated at 580px if needed) |
+| `displayUrl` | `string` | Breadcrumb path (e.g. `example.com › blog › post`) |
+| `description` | `string` | Display description (truncated at 920px if needed) |
+| `titleTruncated` | `boolean` | Whether title was truncated |
+| `descriptionTruncated` | `boolean` | Whether description was truncated |
+| `titleValidation` | `ValidationResult` | Title length/pixel validation result |
+| `descriptionValidation` | `ValidationResult` | Description length/pixel validation result |
 
 ---
 
-### `generateOgPreview(input)`
+### `generateOgPreview()`
 
 ```ts
 function generateOgPreview(input: OgPreviewInput): OgPreviewData;
 ```
 
-| Input Prop    | Type                       | Description                     |
-| ------------- | -------------------------- | ------------------------------- |
-| `title`       | `string`                   | OG title                        |
-| `description` | `string`                   | OG description                  |
-| `url`         | `string`                   | Canonical URL                   |
-| `siteName`    | `string`                   | Site name                       |
-| `image`       | `{ url, width?, height? }` | OG image (recommended 1200×630) |
+#### `OgPreviewInput`
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `title` | `string` | ✅ | OG title |
+| `description` | `string` | ✅ | OG description |
+| `url` | `string` | ✅ | Canonical URL |
+| `image` | `{ url: string; width?: number; height?: number }` | — | OG image (recommended 1200×630) |
+| `siteName` | `string` | — | Site name displayed on the card |
+
+#### `OgPreviewData`
+
+| Output Field | Type | Description |
+| --- | --- | --- |
+| `title` | `string` | OG title |
+| `description` | `string` | OG description |
+| `url` | `string` | Canonical URL |
+| `siteName` | `string \| undefined` | Site name |
+| `image` | `OgImageValidation \| undefined` | Image with validation result (see below) |
+
+#### `OgImageValidation`
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `url` | `string` | Image URL |
+| `width` | `number \| undefined` | Image width in pixels |
+| `height` | `number \| undefined` | Image height in pixels |
+| `valid` | `boolean` | Whether the image meets OG dimension requirements |
+| `message` | `string \| undefined` | Human-readable validation message when dimensions deviate |
 
 ---
 
-### `generateTwitterPreview(input)`
+### `generateTwitterPreview()`
 
 ```ts
 function generateTwitterPreview(input: TwitterPreviewInput): TwitterPreviewData;
 ```
 
-| Input Prop    | Type                                 | Description                                |
-| ------------- | ------------------------------------ | ------------------------------------------ |
-| `cardType`    | `'summary' \| 'summary_large_image'` | Twitter Card type                          |
-| `title`       | `string`                             | Card title (max 70 chars displayed)        |
-| `description` | `string`                             | Card description (max 200 chars displayed) |
-| `site`        | `string`                             | Twitter @username of site                  |
-| `image`       | `{ url, width?, height? }`           | Card image                                 |
+#### `TwitterPreviewInput`
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `cardType` | `'summary' \| 'summary_large_image'` | ✅ | Twitter Card type |
+| `title` | `string` | ✅ | Card title |
+| `description` | `string` | ✅ | Card description |
+| `image` | `{ url: string; width?: number; height?: number }` | — | Card image |
+| `site` | `string` | — | Twitter @username of the site (e.g. `'@myblog'`) |
+
+#### `TwitterPreviewData`
+
+| Output Field | Type | Description |
+| --- | --- | --- |
+| `cardType` | `TwitterCardType` | The card type (`'summary'` or `'summary_large_image'`) |
+| `title` | `string` | Card title |
+| `description` | `string` | Card description |
+| `image` | `TwitterImageValidation \| undefined` | Image with validation result |
+| `domain` | `string \| undefined` | Extracted domain from `site` handle |
 
 ---
 
-### `truncateAtPixelWidth(text, maxPixels)`
+### `truncateAtPixelWidth()`
 
 ```ts
 function truncateAtPixelWidth(text: string, maxPixels: number): TruncateResult;
 ```
 
-| Output Field  | Type      | Description                           |
-| ------------- | --------- | ------------------------------------- |
-| `text`        | `string`  | Resulting (possibly truncated) string |
-| `pixelWidth`  | `number`  | Pixel width of the result             |
-| `isTruncated` | `boolean` | Whether truncation occurred           |
+#### `TruncateResult`
+
+| Output Field | Type | Description |
+| --- | --- | --- |
+| `text` | `string` | Resulting (possibly truncated) string |
+| `truncated` | `boolean` | Whether truncation occurred |
 
 ---
 
-## Contributing
+### React Components
 
-- Issues: [github.com/cybercraftbd/power-seo/issues](https://github.com/cybercraftbd/power-seo/issues)
-- PRs: [github.com/cybercraftbd/power-seo/pulls](https://github.com/cybercraftbd/power-seo/pulls)
-- Development setup:
-  1. `pnpm i`
-  2. `pnpm build`
-  3. `pnpm test`
+Import all components from `@power-seo/preview/react`.
 
-**Release workflow**
+```ts
+import { SerpPreview, OgPreview, TwitterPreview, PreviewPanel } from '@power-seo/preview/react';
+```
 
-- `npm version patch|minor|major`
-- `npm publish --access public`
+#### `SerpPreview`
+
+Renders a Google-style SERP result card.
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `title` | `string` | ✅ | Page title |
+| `description` | `string` | ✅ | Meta description |
+| `url` | `string` | ✅ | Canonical URL |
+| `siteTitle` | `string` | — | Site name — appended to title as `"title - siteTitle"` |
+
+#### `OgPreview`
+
+Renders a Facebook/Open Graph card mockup.
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `title` | `string` | ✅ | OG title |
+| `description` | `string` | ✅ | OG description |
+| `url` | `string` | ✅ | Canonical URL |
+| `image` | `{ url: string; width?: number; height?: number }` | — | OG image |
+| `siteName` | `string` | — | Site name shown above the title |
+
+#### `TwitterPreview`
+
+Renders a Twitter/X card mockup for `summary` or `summary_large_image` card types.
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `cardType` | `TwitterCardType` | ✅ | `'summary'` or `'summary_large_image'` |
+| `title` | `string` | ✅ | Card title |
+| `description` | `string` | ✅ | Card description |
+| `image` | `{ url: string; width?: number; height?: number }` | — | Card image |
+| `site` | `string` | — | Twitter @username of the site |
+
+#### `PreviewPanel`
+
+Tabbed container with Google, Facebook, and Twitter/X preview cards in a single component.
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `title` | `string` | ✅ | Page title |
+| `description` | `string` | ✅ | Meta description |
+| `url` | `string` | ✅ | Canonical URL |
+| `image` | `{ url: string; width?: number; height?: number }` | — | Shared image for OG and Twitter cards |
+| `siteName` | `string` | — | OG site name |
+| `siteTitle` | `string` | — | SERP site name (appended to title) |
+| `twitterSite` | `string` | — | Twitter @username |
+| `twitterCardType` | `TwitterCardType` | — | Twitter Card type (default: `'summary_large_image'`) |
 
 ---
 
-## About [CyberCraft Bangladesh](https://ccbd.dev)
+### Types
 
-**[CyberCraft Bangladesh](https://ccbd.dev)** is a Bangladesh-based enterprise-grade software engineering company specializing in ERP system development, AI-powered SaaS and business applications, full-stack SEO services, custom website development, and scalable eCommerce platforms. We design and develop intelligent, automation-driven SaaS and enterprise solutions that help startups, SMEs, NGOs, educational institutes, and large organizations streamline operations, enhance digital visibility, and accelerate growth through modern cloud-native technologies.
-
-|                      |                                                                |
-| -------------------- | -------------------------------------------------------------- |
-| **Website**          | [ccbd.dev](https://ccbd.dev)                                   |
-| **GitHub**           | [github.com/cybercraftbd](https://github.com/cybercraftbd)     |
-| **npm Organization** | [npmjs.com/org/power-seo](https://www.npmjs.com/org/power-seo) |
-| **Email**            | [info@ccbd.dev](mailto:info@ccbd.dev)                          |
+| Type | Description |
+| --- | --- |
+| `SerpPreviewInput` | Input shape for `generateSerpPreview()` |
+| `SerpPreviewData` | Output shape from `generateSerpPreview()` |
+| `OgPreviewInput` | Input shape for `generateOgPreview()` |
+| `OgPreviewData` | Output shape from `generateOgPreview()` |
+| `OgImageValidation` | Image validation result on `OgPreviewData.image` |
+| `TwitterPreviewInput` | Input shape for `generateTwitterPreview()` |
+| `TwitterPreviewData` | Output shape from `generateTwitterPreview()` |
+| `TwitterImageValidation` | Image validation result on `TwitterPreviewData.image` |
+| `TruncateResult` | Output shape from `truncateAtPixelWidth()` |
+| `TwitterCardType` | `'summary' \| 'summary_large_image'` (from `@power-seo/core`) |
+| `ValidationResult` | Title/description validation result (from `@power-seo/core`) |
 
 ---
 
-## License
+## Use Cases
 
-**MIT**
+- **CMS live preview panels** — show authors how their title and description appear in Google before publishing
+- **SEO auditing pipelines** — detect truncated titles and invalid OG images at build time
+- **Programmatic SEO sites** — validate auto-generated titles for thousands of pages at once
+- **Social media schedulers** — validate OG image dimensions before queuing posts
+- **SaaS marketing dashboards** — show SERP and social card previews for every page
+- **Blog platforms** — live preview as editors type the meta description
+- **eCommerce product pages** — ensure product image dimensions meet OG card requirements
+- **Landing page builders** — embed SERP and social card previews in the editor UI
+- **CI content quality gates** — fail builds when SERP titles are truncated or OG images are too small
+
+---
+
+## Architecture Overview
+
+- **Pure TypeScript** — no compiled binary, no native modules
+- **Zero runtime dependencies** — only `@power-seo/core` as a peer dependency
+- **Character-width lookup** — pixel truncation uses per-character width tables matching Google's SERP font metrics, not character counts
+- **Framework-agnostic** — works in any JavaScript environment
+- **SSR compatible** — safe to run in Next.js Server Components, Remix loaders, or Express handlers
+- **Edge runtime safe** — no Node.js-specific APIs; no `fs`, no `canvas`; runs in Cloudflare Workers, Vercel Edge, Deno
+- **Tree-shakeable** — `"sideEffects": false` with named exports per generator function
+- **Dual ESM + CJS** — ships both formats via tsup for any bundler or `require()` usage
+- **React optional** — React is a peer dependency; the `/react` subpath is only included when React is present
+
+---
+
+## Supply Chain Security
+
+- No install scripts (`postinstall`, `preinstall`)
+- No runtime network access
+- No `eval` or dynamic code execution
+- npm provenance enabled — every release is signed via Sigstore through GitHub Actions
+- CI-signed builds — all releases published via verified `github.com/CyberCraftBD/power-seo` workflow
+- Safe for SSR, Edge, and server environments
+
+---
+
+## The [@power-seo](https://www.npmjs.com/org/power-seo) Ecosystem
+
+All 17 packages are independently installable — use only what you need.
+
+| Package | Install | Description |
+| --- | --- | --- |
+| [`@power-seo/core`](https://www.npmjs.com/package/@power-seo/core) | `npm i @power-seo/core` | Framework-agnostic utilities, types, validators, and constants |
+| [`@power-seo/react`](https://www.npmjs.com/package/@power-seo/react) | `npm i @power-seo/react` | React SEO components — meta, Open Graph, Twitter Card, breadcrumbs |
+| [`@power-seo/meta`](https://www.npmjs.com/package/@power-seo/meta) | `npm i @power-seo/meta` | SSR meta helpers for Next.js App Router, Remix v2, and generic SSR |
+| [`@power-seo/schema`](https://www.npmjs.com/package/@power-seo/schema) | `npm i @power-seo/schema` | Type-safe JSON-LD structured data — 20 builders + 18 React components |
+| [`@power-seo/content-analysis`](https://www.npmjs.com/package/@power-seo/content-analysis) | `npm i @power-seo/content-analysis` | Yoast-style SEO content scoring engine with React components |
+| [`@power-seo/readability`](https://www.npmjs.com/package/@power-seo/readability) | `npm i @power-seo/readability` | Readability scoring — Flesch-Kincaid, Gunning Fog, Coleman-Liau, ARI |
+| [`@power-seo/preview`](https://www.npmjs.com/package/@power-seo/preview) | `npm i @power-seo/preview` | SERP, Open Graph, and Twitter/X Card preview generators |
+| [`@power-seo/sitemap`](https://www.npmjs.com/package/@power-seo/sitemap) | `npm i @power-seo/sitemap` | XML sitemap generation, streaming, index splitting, and validation |
+| [`@power-seo/redirects`](https://www.npmjs.com/package/@power-seo/redirects) | `npm i @power-seo/redirects` | Redirect engine with Next.js, Remix, and Express adapters |
+| [`@power-seo/links`](https://www.npmjs.com/package/@power-seo/links) | `npm i @power-seo/links` | Link graph analysis — orphan detection, suggestions, equity scoring |
+| [`@power-seo/audit`](https://www.npmjs.com/package/@power-seo/audit) | `npm i @power-seo/audit` | Full SEO audit engine — meta, content, structure, performance rules |
+| [`@power-seo/images`](https://www.npmjs.com/package/@power-seo/images) | `npm i @power-seo/images` | Image SEO — alt text, lazy loading, format analysis, image sitemaps |
+| [`@power-seo/ai`](https://www.npmjs.com/package/@power-seo/ai) | `npm i @power-seo/ai` | LLM-agnostic AI prompt templates and parsers for SEO tasks |
+| [`@power-seo/analytics`](https://www.npmjs.com/package/@power-seo/analytics) | `npm i @power-seo/analytics` | Merge GSC + audit data, trend analysis, ranking insights, dashboard |
+| [`@power-seo/search-console`](https://www.npmjs.com/package/@power-seo/search-console) | `npm i @power-seo/search-console` | Google Search Console API — OAuth2, service account, URL inspection |
+| [`@power-seo/integrations`](https://www.npmjs.com/package/@power-seo/integrations) | `npm i @power-seo/integrations` | Semrush and Ahrefs API clients with rate limiting and pagination |
+| [`@power-seo/tracking`](https://www.npmjs.com/package/@power-seo/tracking) | `npm i @power-seo/tracking` | GA4, Clarity, PostHog, Plausible, Fathom — scripts + consent management |
 
 ---
 
 ## Keywords
 
-```text
-seo, serp, preview, serp-preview, open-graph, twitter-card, og-preview, pixel-truncation, meta-description, typescript, nextjs, remix, cms-preview, social-preview
-```
+seo preview · serp preview · open graph preview · twitter card preview · pixel truncation · meta description truncation · serp snippet generator · og image validation · typescript seo · nextjs seo preview · react serp preview · cms preview panel · social card preview · seo audit npm · programmatic seo · pixel-accurate truncation · og card validator · twitter card validator · seo tooling typescript · headless seo preview
+
+---
+
+## About [CyberCraft Bangladesh](https://ccbd.dev)
+
+**[CyberCraft Bangladesh](https://ccbd.dev)** is a Bangladesh-based enterprise-grade software development and Full Stack SEO service provider company specializing in ERP system development, AI-powered SaaS and business applications, full-stack SEO services, custom website development, and scalable eCommerce platforms. We design and develop intelligent, automation-driven SaaS and enterprise solutions that help startups, SMEs, NGOs, educational institutes, and large organizations streamline operations, enhance digital visibility, and accelerate growth through modern cloud-native technologies.
+
+[![Website](https://img.shields.io/badge/Website-ccbd.dev-blue?style=for-the-badge)](https://ccbd.dev)
+[![GitHub](https://img.shields.io/badge/GitHub-cybercraftbd-black?style=for-the-badge&logo=github)](https://github.com/cybercraftbd)
+[![npm](https://img.shields.io/badge/npm-power--seo-red?style=for-the-badge&logo=npm)](https://www.npmjs.com/org/power-seo)
+[![Email](https://img.shields.io/badge/Email-info@ccbd.dev-green?style=for-the-badge&logo=gmail)](mailto:info@ccbd.dev)
+
+© 2026 [CyberCraft Bangladesh](https://ccbd.dev) · Released under the [MIT License](../../LICENSE)

--- a/packages/preview/tsup.config.ts
+++ b/packages/preview/tsup.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
   external: ['react', 'react-dom'],
 });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,97 +1,104 @@
-# @power-seo/react — React SEO Components for Meta Tags, Open Graph, Twitter Card, Robots & Breadcrumbs
+# @power-seo/react
 
 [![npm version](https://img.shields.io/npm/v/@power-seo/react)](https://www.npmjs.com/package/@power-seo/react)
 [![npm downloads](https://img.shields.io/npm/dm/@power-seo/react)](https://www.npmjs.com/package/@power-seo/react)
+[![Socket](https://socket.dev/api/badge/npm/package/@power-seo/react)](https://socket.dev/npm/package/@power-seo/react)
+[![npm provenance](https://img.shields.io/badge/npm-provenance-enabled-blue)](https://github.com/CyberCraftBD/power-seo/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-%3E%3D18-61DAFB)](https://react.dev/)
 [![tree-shakeable](https://img.shields.io/badge/tree--shakeable-yes-brightgreen)](https://bundlephobia.com/package/@power-seo/react)
 
----
+Declarative React components for SEO meta tag management — title templates, Open Graph, Twitter Cards, canonical URLs, robots directives, hreflang, and breadcrumbs with JSON-LD, all from a single composable API that renders directly to the DOM.
 
-## Overview
-
-**@power-seo/react** is a complete set of declarative React components for SEO meta tag management for Next.js Pages Router, Vite, Gatsby, and any React application that renders to the DOM, helping you manage titles, Open Graph, Twitter Cards, canonical URLs, robots directives, hreflang, and breadcrumbs from a single composable API.
-
-**What it does**
-
-- ✅ **All-in-one `<SEO>` component** — renders title, meta description, canonical, robots, Open Graph, and Twitter Card from one component
-- ✅ **Context-based defaults** — `<DefaultSEO>` at app root sets site-wide defaults; pages override selectively
-- ✅ **Full robots directive support** — all 10 directives including `noindex`, `noarchive`, `max-snippet`, `max-image-preview`, `unavailable_after`
-- ✅ **Hreflang internationalization** — `<Hreflang>` renders `<link rel="alternate">` tags for multi-language sites
-- ✅ **Breadcrumbs with JSON-LD** — `<Breadcrumb>` renders visible nav plus embedded BreadcrumbList structured data
-
-**What it is not**
-
-- ❌ **Not an App Router solution** — use `@power-seo/meta` for Next.js App Router `generateMetadata()`
-- ❌ **Not server-side only** — requires `react-helmet-async` under the hood; targets DOM-rendering React apps
-
-**Recommended for**
-
-- **Next.js Pages Router apps**, **Vite + React SPAs**, **Gatsby sites**, and **Create React App projects**
+> **Zero third-party dependencies** — only `react` and `@power-seo/core` as peers.
 
 ---
 
-## Why @power-seo/react Matters
+## Why @power-seo/react?
 
-**The problem**
-
-- **Scattered meta tag management** — teams add `<Helmet>` blocks inconsistently across hundreds of components
-- **Missing Open Graph images** — no single source of truth for default OG images leads to bare link previews
-- **Incorrect robots directives** — hand-crafted `content` strings omit valid directives or include typos
-
-**Why developers care**
-
-- **SEO:** Consistent title templates and canonical URLs prevent duplicate content penalties
-- **UX:** Correct OG and Twitter Card images dramatically increase social click-through
-- **Performance:** Centralized `<DefaultSEO>` prevents redundant meta tag renders on every page
+| | Without | With |
+|---|---|---|
+| Title management | ❌ Ad-hoc `<title>` tags per page | ✅ `<DefaultSEO>` enforces site-wide title template |
+| Open Graph | ❌ Missing or inconsistent `og:*` tags | ✅ Typed `<OpenGraph>` and `<SEO openGraph={...}>` |
+| Twitter Cards | ❌ Hand-coded `twitter:*` strings | ✅ Typed `<TwitterCard>` with all card types |
+| Robots directives | ❌ Raw content strings with typos | ✅ Boolean and enum props — no raw string errors |
+| Canonical URLs | ❌ Omitted or duplicated | ✅ `<Canonical>` and `<SEO canonical={...}>` |
+| Hreflang | ❌ Manual `<link>` tags per locale | ✅ `<Hreflang>` renders all alternates + x-default |
+| Breadcrumbs | ❌ HTML nav only, no structured data | ✅ `<Breadcrumb>` renders nav + BreadcrumbList JSON-LD |
+| Framework support | ❌ Locked to next-seo or react-helmet | ✅ Next.js Pages Router, Vite, Gatsby, React 18/19 |
 
 ---
 
-## Key Features
+## Features
 
-- **`<SEO>` all-in-one component** — renders title, meta description, canonical, robots, Open Graph, and Twitter Card tags from a single component
-- **`<DefaultSEO>` context-based defaults** — set site-wide title template, default OG image, and global robots directives; individual pages override selectively
-- **`<Robots>` full directive support** — all 10 robots directives including `noindex`, `nofollow`, `noarchive`, `nosnippet`, `noimageindex`, `notranslate`, `max-snippet`, `max-image-preview`, `max-video-preview`, `unavailable_after`
+- **`<SEO>` all-in-one component** — renders title, meta description, canonical, robots, Open Graph, and Twitter Card from a single component
+- **`<DefaultSEO>` context-based defaults** — set site-wide title template, default OG image, and global robots directives at the app root; pages override selectively
+- **`<Robots>` full directive support** — all 10 directives including `noindex`, `nofollow`, `noarchive`, `nosnippet`, `noimageindex`, `notranslate`, `max-snippet`, `max-image-preview`, `max-video-preview`, `unavailable_after`
 - **`<OpenGraph>` all OG properties** — `og:title`, `og:description`, `og:type`, `og:url`, `og:image` (with width/height/alt), `og:site_name`, `og:locale`, `og:article:*` properties
 - **`<TwitterCard>` all card types** — `summary`, `summary_large_image`, `app`, `player`; with site, creator, title, description, image
-- **`<Canonical>` link tag** — renders `<link rel="canonical">` with proper href
+- **`<Canonical>` link tag** — renders `<link rel="canonical">` with proper href; supports base URL resolution and trailing slash control
 - **`<Hreflang>` i18n alternate links** — renders `<link rel="alternate" hreflang="...">` tags for multi-language sites including `x-default`
-- **`<Breadcrumb>` with JSON-LD** — renders visible breadcrumb navigation plus embedded `application/ld+json` BreadcrumbList
+- **`<Breadcrumb>` with JSON-LD** — renders visible breadcrumb navigation plus embedded `application/ld+json` BreadcrumbList structured data
+- **`renderMetaTags` / `renderLinkTags` utilities** — convert `@power-seo/core` tag arrays into React elements
+- **React 19 native hoisting** — `<title>`, `<meta>`, and `<link>` tags hoist to `<head>` automatically in React 19; works with framework Head components in React 18
 - **TypeScript-first** — full `.d.ts` declarations, all props fully typed
 - **Tree-shakeable** — import only the components you use
 
 ---
 
-## Benefits of Using @power-seo/react
+## Comparison
 
-- **Improved consistency**: `<DefaultSEO>` enforces site-wide title templates and OG defaults with zero duplication
-- **Better social visibility**: Correct `<TwitterCard>` and `<OpenGraph>` images increase social click-through rates
-- **Safer SEO implementation**: Typed robots directive props prevent typos that could accidentally noindex pages
-- **Faster delivery**: Drop-in components eliminate boilerplate meta tag code from every page component
+| Feature                          | @power-seo/react | next-seo | react-helmet | react-helmet-async |
+| -------------------------------- | :--------------: | :------: | :----------: | :----------------: |
+| Typed robots directives          | ✅               | ✅       | ❌           | ❌                 |
+| DefaultSEO context pattern       | ✅               | ✅       | ❌           | ❌                 |
+| Hreflang support                 | ✅               | ✅       | ❌           | ❌                 |
+| Breadcrumb with JSON-LD          | ✅               | ✅       | ❌           | ❌                 |
+| `max-snippet` / `max-image-preview` | ✅            | ✅       | ❌           | ❌                 |
+| No third-party runtime deps      | ✅               | ❌       | ❌           | ❌                 |
+| React 19 native head hoisting    | ✅               | ❌       | ❌           | ❌                 |
+| TypeScript-first API             | ✅               | ✅       | ⚠️           | ⚠️                 |
+| Tree-shakeable                   | ✅               | Partial  | ❌           | ❌                 |
+| Works in Next.js Pages Router    | ✅               | ✅       | ✅           | ✅                 |
+| Works in Vite / Gatsby / CRA     | ✅               | ❌       | ✅           | ✅                 |
+
+---
+
+## Installation
+
+```bash
+npm install @power-seo/react @power-seo/core
+```
+
+```bash
+yarn add @power-seo/react @power-seo/core
+```
+
+```bash
+pnpm add @power-seo/react @power-seo/core
+```
 
 ---
 
 ## Quick Start
 
 ```tsx
-import { HelmetProvider } from 'react-helmet-async';
 import { DefaultSEO, SEO } from '@power-seo/react';
 
 function App() {
   return (
-    <HelmetProvider>
-      <DefaultSEO
-        titleTemplate="%s | My Site"
-        defaultTitle="My Site"
-        description="The best site on the internet."
-        openGraph={{ type: 'website', siteName: 'My Site' }}
-        twitter={{ site: '@mysite', cardType: 'summary_large_image' }}
-      />
+    <DefaultSEO
+      titleTemplate="%s | My Site"
+      defaultTitle="My Site"
+      description="The best site on the internet."
+      openGraph={{ type: 'website', siteName: 'My Site' }}
+      twitter={{ site: '@mysite', cardType: 'summary_large_image' }}
+    >
       <Router>
         <Routes />
       </Router>
-    </HelmetProvider>
+    </DefaultSEO>
   );
 }
 
@@ -113,190 +120,223 @@ function BlogPage({ post }) {
 }
 ```
 
-**What you should see**
+**What you get in the DOM `<head>`:**
 
-- `<title>My Post Title | My Site</title>` in the DOM `<head>`
+- `<title>My Post Title | My Site</title>`
 - Correct `og:image`, `twitter:card`, and `link rel="canonical"` tags on every page
 
 ---
 
-## Installation
+## Usage
 
-```bash
-npm i @power-seo/react
-# or
-yarn add @power-seo/react
-# or
-pnpm add @power-seo/react
-# or
-bun add @power-seo/react
+### Site-Wide Defaults with `<DefaultSEO>`
+
+Place `<DefaultSEO>` once at your app root. It stores the config in React context so every nested `<SEO>` component can merge against it.
+
+```tsx
+import { DefaultSEO } from '@power-seo/react';
+
+function App({ children }) {
+  return (
+    <DefaultSEO
+      titleTemplate="%s | Acme Corp"
+      defaultTitle="Acme Corp"
+      description="Enterprise software built for scale."
+      openGraph={{
+        type: 'website',
+        siteName: 'Acme Corp',
+        images: [{ url: 'https://acme.com/og-default.jpg', width: 1200, height: 630 }],
+      }}
+      twitter={{ site: '@acmecorp', cardType: 'summary_large_image' }}
+    >
+      {children}
+    </DefaultSEO>
+  );
+}
 ```
 
-**Peer dependencies:**
+### Per-Page SEO with `<SEO>`
 
-```bash
-npm install react react-dom react-helmet-async
+`<SEO>` merges the page-level config with the `<DefaultSEO>` context. Only provide the props that differ from the site defaults.
+
+```tsx
+import { SEO } from '@power-seo/react';
+
+function ProductPage({ product }) {
+  return (
+    <>
+      <SEO
+        title={product.name}
+        description={product.summary}
+        canonical={`https://acme.com/products/${product.slug}`}
+        openGraph={{
+          type: 'website',
+          images: [{ url: product.image, width: 1200, height: 630, alt: product.name }],
+        }}
+      />
+      <main>{/* page content */}</main>
+    </>
+  );
+}
 ```
 
-> Note: Wrap your app in `<HelmetProvider>` from `react-helmet-async`.
+### Robots Directives
 
----
+Use the `<Robots>` component directly, or pass a `robots` object to `<SEO>`. All 10 standard directives are supported via typed props.
 
-## Framework Compatibility
+```tsx
+import { Robots } from '@power-seo/react';
 
-**Supported**
+// Noindex a staging page
+<Robots index={false} follow={true} />
+// → <meta name="robots" content="noindex, follow" />
 
-- ✅ Next.js Pages Router — works with `_app.tsx` and per-page `<SEO>` components
-- ✅ Vite + React — works in standard SPA setup
-- ✅ Gatsby — works with `gatsby-plugin-react-helmet` or standalone
-- ✅ Create React App — works out of the box
-
-**Environment notes**
-
-- **SSR/SSG:** Supported via `react-helmet-async` (SSR-safe)
-- **Edge runtime:** Not supported (requires DOM/React reconciler)
-- **Next.js App Router:** Not recommended — use `@power-seo/meta` instead for App Router
-
----
-
-## Use Cases
-
-- **Next.js Pages Router sites** — per-page SEO with site-wide defaults
-- **SaaS marketing sites** — consistent OG cards for every landing page
-- **Blog platforms** — article Open Graph with `og:article:publishedTime` and author data
-- **E-commerce listings** — product pages with correct canonical and Twitter Cards
-- **Multi-language sites** — hreflang alternate link management across locale variants
-- **Staging environments** — easily `noindex` entire environments with a single `<DefaultSEO robots={{ index: false }} />`
-- **Breadcrumb navigation** — visible breadcrumbs with embedded JSON-LD for Google rich results
-
----
-
-## Example (Before / After)
-
-```text
-Before:
-- Each page has a different <Helmet> implementation with inconsistent OG formats
-- Some pages missing canonical, some missing twitter:card
-- Robots directives hand-coded as raw strings with typos
-
-After (@power-seo/react):
-- <DefaultSEO> enforces site-wide title template and default OG image
-- <SEO> on each page overrides only what differs — canonical, OG image, article properties
-- <Robots> accepts typed boolean props — no raw content string typos
+// Advanced directives
+<Robots
+  index={true}
+  follow={true}
+  maxSnippet={150}
+  maxImagePreview="large"
+  unavailableAfter="2026-12-31T00:00:00Z"
+/>
+// → <meta name="robots" content="index, follow, max-snippet:150, max-image-preview:large, unavailable_after:2026-12-31T00:00:00Z" />
 ```
 
----
+Use `buildRobotsContent` from `@power-seo/core` if you need the raw robots string outside a component:
 
-## Implementation Best Practices
+```ts
+import { buildRobotsContent } from '@power-seo/core';
 
-- **Always use `<HelmetProvider>`** at the root — required for SSR and correct head management
-- **Set `<DefaultSEO>` once** at the app root — every page inherits defaults without re-declaring
-- **Use `noindex={true}` on `<SEO>`** for staging, admin, and private pages — not in `next.config.js` redirects
-- **Always set `canonical`** on pages with query parameters to prevent duplicate content
-- **Include `x-default` in `<Hreflang>`** to signal the default language for international visitors
+buildRobotsContent({ index: false, follow: true, maxSnippet: 150 });
+// → "noindex, follow, max-snippet:150"
+```
 
----
+### Open Graph Tags
 
-## Architecture Overview
+Use `<OpenGraph>` for standalone OG tag rendering, or pass `openGraph` to `<SEO>`.
 
-**Where it runs**
+```tsx
+import { OpenGraph } from '@power-seo/react';
 
-- **Client-side (CSR):** `react-helmet-async` manages `<head>` updates on navigation
-- **Server-side (SSR):** `HelmetProvider` collects head tags during render and serializes them into the initial HTML
-- **CI/CD:** No direct CI integration — audit head tags with `@power-seo/audit`
+<OpenGraph
+  type="article"
+  title="How to Build a React SEO Pipeline"
+  description="A step-by-step guide to SEO in React applications."
+  url="https://example.com/blog/react-seo"
+  images={[{ url: 'https://example.com/react-seo-og.jpg', width: 1200, height: 630, alt: 'React SEO' }]}
+  article={{
+    publishedTime: '2026-01-15T00:00:00Z',
+    authors: ['https://example.com/author/jane'],
+    tags: ['react', 'seo', 'typescript'],
+  }}
+/>
+```
 
-**Data flow**
+### Twitter Cards
 
-1. **Input**: Page-level title, description, OG config, robots directive props
-2. **Analysis**: `react-helmet-async` merges `<DefaultSEO>` defaults with `<SEO>` overrides
-3. **Output**: Rendered `<head>` tags: `<title>`, `<meta>`, `<link>`, `<script>` (JSON-LD for breadcrumbs)
-4. **Action**: Correct head tags for crawlers, social scrapers, and browser tab display
+Use `<TwitterCard>` for standalone Twitter/X card tag rendering, or pass `twitter` to `<SEO>`.
 
----
+```tsx
+import { TwitterCard } from '@power-seo/react';
 
-## Features Comparison with Popular Packages
+<TwitterCard
+  cardType="summary_large_image"
+  site="@mysite"
+  creator="@author"
+  title="How to Build a React SEO Pipeline"
+  description="A step-by-step guide to SEO in React applications."
+  image="https://example.com/twitter-card.jpg"
+  imageAlt="React SEO guide"
+/>
+```
 
-| Capability                          | next-seo | react-helmet | react-helmet-async | @power-seo/react |
-| ----------------------------------- | -------: | -----------: | -----------------: | ---------------: |
-| Typed robots directives             |       ✅ |           ❌ |                 ❌ |               ✅ |
-| DefaultSEO context pattern          |       ✅ |           ❌ |                 ❌ |               ✅ |
-| Hreflang support                    |       ✅ |           ❌ |                 ❌ |               ✅ |
-| Breadcrumb with JSON-LD             |       ✅ |           ❌ |                 ❌ |               ✅ |
-| `max-snippet` / `max-image-preview` |       ✅ |           ❌ |                 ❌ |               ✅ |
-| TypeScript-first API                |       ✅ |           ⚠️ |                 ⚠️ |               ✅ |
+### Canonical URL
 
----
+```tsx
+import { Canonical } from '@power-seo/react';
 
-## [@power-seo](https://www.npmjs.com/org/power-seo) Ecosystem
+// Absolute URL
+<Canonical url="https://example.com/blog/react-seo" />
 
-All 17 packages are independently installable — use only what you need.
+// With base URL resolution
+<Canonical url="/blog/react-seo" baseUrl="https://example.com" />
+```
 
-| Package                                                                                    | Install                             | Description                                                                |
-| ------------------------------------------------------------------------------------------ | ----------------------------------- | -------------------------------------------------------------------------- |
-| [`@power-seo/core`](https://www.npmjs.com/package/@power-seo/core)                         | `npm i @power-seo/core`             | Framework-agnostic utilities, types, validators, and constants             |
-| [`@power-seo/react`](https://www.npmjs.com/package/@power-seo/react)                       | `npm i @power-seo/react`            | React SEO components — meta, Open Graph, Twitter Card, robots, breadcrumbs |
-| [`@power-seo/meta`](https://www.npmjs.com/package/@power-seo/meta)                         | `npm i @power-seo/meta`             | SSR meta helpers for Next.js App Router, Remix v2, and generic SSR         |
-| [`@power-seo/schema`](https://www.npmjs.com/package/@power-seo/schema)                     | `npm i @power-seo/schema`           | Type-safe JSON-LD structured data — 20 builders + 18 React components      |
-| [`@power-seo/content-analysis`](https://www.npmjs.com/package/@power-seo/content-analysis) | `npm i @power-seo/content-analysis` | Yoast-style SEO content scoring engine with React components               |
-| [`@power-seo/readability`](https://www.npmjs.com/package/@power-seo/readability)           | `npm i @power-seo/readability`      | Readability scoring — Flesch-Kincaid, Gunning Fog, Coleman-Liau, ARI       |
-| [`@power-seo/preview`](https://www.npmjs.com/package/@power-seo/preview)                   | `npm i @power-seo/preview`          | SERP, Open Graph, and Twitter/X Card preview generators                    |
-| [`@power-seo/sitemap`](https://www.npmjs.com/package/@power-seo/sitemap)                   | `npm i @power-seo/sitemap`          | XML sitemap generation, streaming, index splitting, and validation         |
-| [`@power-seo/redirects`](https://www.npmjs.com/package/@power-seo/redirects)               | `npm i @power-seo/redirects`        | Redirect engine with Next.js, Remix, and Express adapters                  |
-| [`@power-seo/links`](https://www.npmjs.com/package/@power-seo/links)                       | `npm i @power-seo/links`            | Link graph analysis — orphan detection, suggestions, equity scoring        |
-| [`@power-seo/audit`](https://www.npmjs.com/package/@power-seo/audit)                       | `npm i @power-seo/audit`            | Full SEO audit engine — meta, content, structure, performance rules        |
-| [`@power-seo/images`](https://www.npmjs.com/package/@power-seo/images)                     | `npm i @power-seo/images`           | Image SEO — alt text, lazy loading, format analysis, image sitemaps        |
-| [`@power-seo/ai`](https://www.npmjs.com/package/@power-seo/ai)                             | `npm i @power-seo/ai`               | LLM-agnostic AI prompt templates and parsers for SEO tasks                 |
-| [`@power-seo/analytics`](https://www.npmjs.com/package/@power-seo/analytics)               | `npm i @power-seo/analytics`        | Merge GSC + audit data, trend analysis, ranking insights, dashboard        |
-| [`@power-seo/search-console`](https://www.npmjs.com/package/@power-seo/search-console)     | `npm i @power-seo/search-console`   | Google Search Console API — OAuth2, service account, URL inspection        |
-| [`@power-seo/integrations`](https://www.npmjs.com/package/@power-seo/integrations)         | `npm i @power-seo/integrations`     | Semrush and Ahrefs API clients with rate limiting and pagination           |
-| [`@power-seo/tracking`](https://www.npmjs.com/package/@power-seo/tracking)                 | `npm i @power-seo/tracking`         | GA4, Clarity, PostHog, Plausible, Fathom — scripts + consent management    |
+### Hreflang for Multi-Language Sites
 
-### Ecosystem vs alternatives
+```tsx
+import { Hreflang } from '@power-seo/react';
 
-| Need                    | Common approach             | @power-seo approach                      |
-| ----------------------- | --------------------------- | ---------------------------------------- |
-| React meta tags         | `next-seo` / `react-helmet` | `@power-seo/react` — typed components    |
-| App Router metadata     | `generateMetadata()`        | `@power-seo/meta` — typed helpers        |
-| JSON-LD structured data | Manual `<script>` tags      | `@power-seo/schema` — typed builders     |
-| Sitemap generation      | `next-sitemap`              | `@power-seo/sitemap` — streaming + index |
+<Hreflang
+  alternates={[
+    { hrefLang: 'en', href: 'https://example.com/en/page' },
+    { hrefLang: 'fr', href: 'https://example.com/fr/page' },
+    { hrefLang: 'de', href: 'https://example.com/de/page' },
+  ]}
+  xDefault="https://example.com/en/page"
+/>
+```
 
----
+### Breadcrumb Navigation with JSON-LD
 
-## Enterprise Integration
+`<Breadcrumb>` renders both the visible `<nav>` element and an embedded `application/ld+json` BreadcrumbList script for Google rich results.
 
-**Multi-tenant SaaS**
+```tsx
+import { Breadcrumb } from '@power-seo/react';
 
-- **Tenant-aware title templates**: Pass tenant name into `<DefaultSEO titleTemplate="%s | {tenantName}" />`
-- **Per-tenant OG images**: Different default OG image per tenant via `<DefaultSEO openGraph={{ images: [...] }} />`
-- **Staging noindex**: Wrap entire staging apps in `<DefaultSEO robots={{ index: false }} />`
+<Breadcrumb
+  items={[
+    { name: 'Home', url: '/' },
+    { name: 'Blog', url: '/blog' },
+    { name: 'React SEO Guide' },
+  ]}
+/>
+```
 
-**ERP / internal portals**
+Customize the separator and styling:
 
-- Apply `noindex, nofollow` globally on internal modules
-- Add breadcrumbs with JSON-LD only on public-facing pages
-- Use `<Hreflang>` for internationalized ERP portals with locale-specific URLs
+```tsx
+<Breadcrumb
+  items={breadcrumbItems}
+  separator=" › "
+  className="breadcrumb-nav"
+  linkClassName="breadcrumb-link"
+  activeClassName="breadcrumb-active"
+  includeJsonLd={true}
+/>
+```
 
-**Recommended integration pattern**
+### Noindexing Entire Environments
 
-- Set `<DefaultSEO>` in `_app.tsx` or root layout
-- Override with `<SEO>` on each page using data fetched server-side
-- Audit head tags in CI using `@power-seo/audit`
+```tsx
+// Noindex all staging pages with a single DefaultSEO prop
+<DefaultSEO
+  robots={{ index: false, follow: false }}
+  titleTemplate="%s | Staging"
+  defaultTitle="Staging"
+>
+  {children}
+</DefaultSEO>
+```
 
----
+### Using `renderMetaTags` and `renderLinkTags`
 
-## Scope and Limitations
+If you generate tag arrays via `@power-seo/core` utilities directly, use these helpers to convert them to React elements:
 
-**This package does**
+```tsx
+import { buildMetaTags, buildLinkTags } from '@power-seo/core';
+import { renderMetaTags, renderLinkTags } from '@power-seo/react';
 
-- ✅ Render React head tag components for DOM-based React apps
-- ✅ Manage title templates, Open Graph, Twitter Cards, robots, canonical, hreflang
-- ✅ Render breadcrumb navigation with embedded JSON-LD
+const metaTags = buildMetaTags({ description: 'My page', noindex: true });
+const linkTags = buildLinkTags({ canonical: 'https://example.com/page' });
 
-**This package does not**
-
-- ❌ Work with Next.js App Router `generateMetadata()` — use `@power-seo/meta` instead
-- ❌ Generate sitemaps — use `@power-seo/sitemap`
-- ❌ Build JSON-LD schemas beyond breadcrumbs — use `@power-seo/schema`
+return (
+  <>
+    {renderMetaTags(metaTags)}
+    {renderLinkTags(linkTags)}
+  </>
+);
+```
 
 ---
 
@@ -304,32 +344,42 @@ All 17 packages are independently installable — use only what you need.
 
 ### Components
 
-| Component       | Description                                                                            |
-| --------------- | -------------------------------------------------------------------------------------- |
-| `<SEO>`         | All-in-one per-page SEO component — title, description, canonical, robots, OG, Twitter |
-| `<DefaultSEO>`  | App-root defaults — title template, global OG, global Twitter, global robots           |
-| `<Robots>`      | Renders `<meta name="robots">` with all supported directives                           |
-| `<OpenGraph>`   | Renders Open Graph `og:*` meta tags                                                    |
-| `<TwitterCard>` | Renders Twitter Card `twitter:*` meta tags                                             |
-| `<Canonical>`   | Renders `<link rel="canonical">`                                                       |
-| `<Hreflang>`    | Renders `<link rel="alternate" hreflang="...">` tags                                   |
-| `<Breadcrumb>`  | Renders breadcrumb nav + embedded BreadcrumbList JSON-LD                               |
+| Component       | Description                                                                             |
+| --------------- | --------------------------------------------------------------------------------------- |
+| `<DefaultSEO>`  | App-root defaults — title template, global OG, global Twitter, global robots; wraps children with SEO context |
+| `<SEO>`         | All-in-one per-page SEO component — title, description, canonical, robots, OG, Twitter  |
+| `<Robots>`      | Renders `<meta name="robots">` with all supported directives                            |
+| `<OpenGraph>`   | Renders Open Graph `og:*` meta tags                                                     |
+| `<TwitterCard>` | Renders Twitter Card `twitter:*` meta tags                                              |
+| `<Canonical>`   | Renders `<link rel="canonical">`                                                        |
+| `<Hreflang>`    | Renders `<link rel="alternate" hreflang="...">` tags                                    |
+| `<Breadcrumb>`  | Renders breadcrumb nav + embedded BreadcrumbList JSON-LD                                |
 
 ### SEO Props
 
-| Prop                 | Type              | Default | Description                                                     |
-| -------------------- | ----------------- | ------- | --------------------------------------------------------------- |
-| `title`              | `string`          | —       | Page title (applied to title template if DefaultSEO is present) |
-| `description`        | `string`          | —       | Meta description                                                |
-| `canonical`          | `string`          | —       | Canonical URL                                                   |
-| `robots`             | `RobotsDirective` | —       | Robots directive config object                                  |
-| `openGraph`          | `OpenGraphConfig` | —       | Open Graph configuration                                        |
-| `twitter`            | `TwitterConfig`   | —       | Twitter Card configuration                                      |
-| `noindex`            | `boolean`         | `false` | Shorthand for `robots.index = false`                            |
-| `nofollow`           | `boolean`         | `false` | Shorthand for `robots.follow = false`                           |
-| `languageAlternates` | `HreflangEntry[]` | —       | Hreflang entries for i18n                                       |
-| `additionalMetaTags` | `MetaTag[]`       | —       | Any additional custom meta tags                                 |
-| `additionalLinkTags` | `LinkTag[]`       | —       | Any additional custom link tags                                 |
+| Prop                 | Type                  | Default | Description                                                      |
+| -------------------- | --------------------- | ------- | ---------------------------------------------------------------- |
+| `title`              | `string`              | —       | Page title (applied to title template if `DefaultSEO` is present) |
+| `defaultTitle`       | `string`              | —       | Fallback title when no `title` prop is provided                  |
+| `titleTemplate`      | `string`              | —       | Template string; `%s` is replaced by `title` (e.g. `"%s \| Site"`) |
+| `description`        | `string`              | —       | Meta description                                                 |
+| `canonical`          | `string`              | —       | Canonical URL                                                    |
+| `robots`             | `RobotsDirective`     | —       | Robots directive config object                                   |
+| `openGraph`          | `OpenGraphConfig`     | —       | Open Graph configuration                                         |
+| `twitter`            | `TwitterCardConfig`   | —       | Twitter Card configuration                                       |
+| `noindex`            | `boolean`             | `false` | Shorthand for `robots.index = false`                             |
+| `nofollow`           | `boolean`             | `false` | Shorthand for `robots.follow = false`                            |
+| `languageAlternates` | `HreflangEntry[]`     | —       | Hreflang entries for i18n                                        |
+| `additionalMetaTags` | `MetaTag[]`           | —       | Additional custom meta tags                                      |
+| `additionalLinkTags` | `LinkTag[]`           | —       | Additional custom link tags                                      |
+
+### DefaultSEO Props
+
+`<DefaultSEO>` accepts all `SEO` props plus:
+
+| Prop       | Type        | Default | Description                                     |
+| ---------- | ----------- | ------- | ----------------------------------------------- |
+| `children` | `ReactNode` | —       | App subtree that inherits the SEO context defaults |
 
 ### Robots Props
 
@@ -346,65 +396,140 @@ All 17 packages are independently installable — use only what you need.
 | `maxVideoPreview`  | `number`                          | —       | Max video preview duration in seconds                 |
 | `unavailableAfter` | `string`                          | —       | ISO 8601 date after which to remove page from results |
 
+### Canonical Props
+
+| Prop            | Type      | Default | Description                                       |
+| --------------- | --------- | ------- | ------------------------------------------------- |
+| `url`           | `string`  | —       | **Required.** The canonical URL                   |
+| `baseUrl`       | `string`  | —       | Base URL for resolving relative `url` values      |
+| `trailingSlash` | `boolean` | `false` | Append trailing slash to the resolved URL         |
+
+### Hreflang Props
+
+| Prop         | Type               | Default | Description                                                   |
+| ------------ | ------------------ | ------- | ------------------------------------------------------------- |
+| `alternates` | `HreflangConfig[]` | —       | **Required.** Array of `{ hrefLang: string; href: string }` objects |
+| `xDefault`   | `string`           | —       | URL for the `x-default` alternate link tag                    |
+
 ### Breadcrumb Props
 
-| Prop              | Type               | Default | Description                                                     |
-| ----------------- | ------------------ | ------- | --------------------------------------------------------------- |
-| `items`           | `BreadcrumbItem[]` | —       | **Required.** Array of `{ name: string; url?: string }` objects |
-| `separator`       | `string`           | `'/'`   | Visual separator between breadcrumb items                       |
-| `className`       | `string`           | —       | CSS class for the outer `<nav>` element                         |
-| `itemClassName`   | `string`           | —       | CSS class for each `<span>` item                                |
-| `activeClassName` | `string`           | —       | CSS class for the last (current) item                           |
-| `renderJsonLd`    | `boolean`          | `true`  | Whether to render the BreadcrumbList JSON-LD script             |
+| Prop              | Type               | Default  | Description                                                     |
+| ----------------- | ------------------ | -------- | --------------------------------------------------------------- |
+| `items`           | `BreadcrumbItem[]` | —        | **Required.** Array of `{ name: string; url?: string }` objects |
+| `separator`       | `string`           | `' / '`  | Visual separator between breadcrumb items                       |
+| `className`       | `string`           | —        | CSS class for the outer `<nav>` element                         |
+| `linkClassName`   | `string`           | —        | CSS class for each `<a>` link element                           |
+| `activeClassName` | `string`           | —        | CSS class for the last (current) item `<span>`                  |
+| `includeJsonLd`   | `boolean`          | `true`   | Whether to render the BreadcrumbList JSON-LD script             |
 
 ### Utility Functions
 
-```ts
-import { buildRobotsContent, parseRobotsContent } from '@power-seo/react';
+| Function          | Signature                              | Description                                            |
+| ----------------- | -------------------------------------- | ------------------------------------------------------ |
+| `renderMetaTags`  | `(tags: MetaTag[]) => ReactElement`    | Converts `@power-seo/core` MetaTag array to React elements |
+| `renderLinkTags`  | `(tags: LinkTag[]) => ReactElement`    | Converts `@power-seo/core` LinkTag array to React elements |
 
-buildRobotsContent({ index: false, follow: true, maxSnippet: 150 });
-// → "noindex, follow, max-snippet:150"
-```
+### Hooks
 
----
-
-## Contributing
-
-- Issues: [github.com/cybercraftbd/power-seo/issues](https://github.com/cybercraftbd/power-seo/issues)
-- PRs: [github.com/cybercraftbd/power-seo/pulls](https://github.com/cybercraftbd/power-seo/pulls)
-- Development setup:
-  1. `pnpm i`
-  2. `pnpm build`
-  3. `pnpm test`
-
-**Release workflow**
-
-- `npm version patch|minor|major`
-- `npm publish --access public`
+| Hook            | Signature                          | Description                                                             |
+| --------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| `useDefaultSEO` | `() => SEOConfig \| null`          | Returns the current `DefaultSEO` config from React context              |
 
 ---
 
-## About [CyberCraft Bangladesh](https://ccbd.dev)
+## Types
 
-**[CyberCraft Bangladesh](https://ccbd.dev)** is a Bangladesh-based enterprise-grade software engineering company specializing in ERP system development, AI-powered SaaS and business applications, full-stack SEO services, custom website development, and scalable eCommerce platforms. We design and develop intelligent, automation-driven SaaS and enterprise solutions that help startups, SMEs, NGOs, educational institutes, and large organizations streamline operations, enhance digital visibility, and accelerate growth through modern cloud-native technologies.
-
-|                      |                                                                |
-| -------------------- | -------------------------------------------------------------- |
-| **Website**          | [ccbd.dev](https://ccbd.dev)                                   |
-| **GitHub**           | [github.com/cybercraftbd](https://github.com/cybercraftbd)     |
-| **npm Organization** | [npmjs.com/org/power-seo](https://www.npmjs.com/org/power-seo) |
-| **Email**            | [info@ccbd.dev](mailto:info@ccbd.dev)                          |
+| Type                | Description                                                              |
+| ------------------- | ------------------------------------------------------------------------ |
+| `SEOProps`          | Alias of `SEOConfig` from `@power-seo/core`                              |
+| `DefaultSEOProps`   | `SEOConfig & { children?: ReactNode }`                                   |
+| `RobotsProps`       | Alias of `RobotsDirective` from `@power-seo/core`                        |
+| `OpenGraphProps`    | Alias of `OpenGraphConfig` from `@power-seo/core`                        |
+| `TwitterCardProps`  | Alias of `TwitterCardConfig` from `@power-seo/core`                      |
+| `CanonicalProps`    | `{ url: string; baseUrl?: string; trailingSlash?: boolean }`             |
+| `HreflangProps`     | `{ alternates: HreflangConfig[]; xDefault?: string }`                    |
+| `BreadcrumbProps`   | See Breadcrumb Props table above                                          |
+| `BreadcrumbItem`    | `{ name: string; url?: string }`                                         |
 
 ---
 
-## License
+## Use Cases
 
-**MIT**
+- **Next.js Pages Router sites** — per-page SEO with site-wide defaults via `_app.tsx`
+- **Vite + React SPAs** — manage head tags in single-page apps without a full meta framework
+- **Gatsby sites** — declarative SEO components alongside Gatsby's static rendering
+- **SaaS marketing sites** — consistent OG cards and title templates across every landing page
+- **Blog platforms** — article Open Graph with `og:article:publishedTime` and author tags
+- **E-commerce listings** — product canonical URLs and Twitter Cards at scale
+- **Multi-language sites** — hreflang alternate link management across locale variants
+- **Staging environments** — easily `noindex` entire environments with a single `<DefaultSEO robots={{ index: false }} />`
+- **Breadcrumb navigation** — visible breadcrumbs with embedded JSON-LD for Google rich results
+
+---
+
+## Architecture Overview
+
+- **Pure React** — no compiled binary, no native modules, no third-party head management library
+- **Zero runtime dependencies** — only `react` and `@power-seo/core` as peer dependencies
+- **React 19 native hoisting** — `<title>`, `<meta>`, and `<link>` elements hoist to `<head>` automatically in React 19; wrap with a framework Head component in React 18
+- **Context-based defaults** — `<DefaultSEO>` uses `React.createContext` so defaults flow through the tree without prop drilling
+- **DOM-targeting** — renders directly to the browser DOM; for Next.js App Router use `@power-seo/meta` instead
+- **Tree-shakeable** — `"sideEffects": false` with named exports per component
+- **Dual ESM + CJS** — ships both formats via tsup for any bundler or `require()` usage
+- **Full TypeScript** — all component props, config types, and utility function signatures are exported
+
+---
+
+## Supply Chain Security
+
+- No install scripts (`postinstall`, `preinstall`)
+- No runtime network access
+- No `eval` or dynamic code execution
+- npm provenance enabled — every release is signed via Sigstore through GitHub Actions
+- CI-signed builds — all releases published via verified `github.com/CyberCraftBD/power-seo` workflow
+- Safe for SSR, Edge-adjacent, and server environments
+
+---
+
+## The [@power-seo](https://www.npmjs.com/org/power-seo) Ecosystem
+
+All 17 packages are independently installable — use only what you need.
+
+| Package                                                                                    | Install                             | Description                                                             |
+| ------------------------------------------------------------------------------------------ | ----------------------------------- | ----------------------------------------------------------------------- |
+| [`@power-seo/core`](https://www.npmjs.com/package/@power-seo/core)                         | `npm i @power-seo/core`             | Framework-agnostic utilities, types, validators, and constants          |
+| [`@power-seo/react`](https://www.npmjs.com/package/@power-seo/react)                       | `npm i @power-seo/react`            | React SEO components — meta, Open Graph, Twitter Card, breadcrumbs      |
+| [`@power-seo/meta`](https://www.npmjs.com/package/@power-seo/meta)                         | `npm i @power-seo/meta`             | SSR meta helpers for Next.js App Router, Remix v2, and generic SSR      |
+| [`@power-seo/schema`](https://www.npmjs.com/package/@power-seo/schema)                     | `npm i @power-seo/schema`           | Type-safe JSON-LD structured data — 20 builders + 18 React components   |
+| [`@power-seo/content-analysis`](https://www.npmjs.com/package/@power-seo/content-analysis) | `npm i @power-seo/content-analysis` | Yoast-style SEO content scoring engine with React components            |
+| [`@power-seo/readability`](https://www.npmjs.com/package/@power-seo/readability)           | `npm i @power-seo/readability`      | Readability scoring — Flesch-Kincaid, Gunning Fog, Coleman-Liau, ARI    |
+| [`@power-seo/preview`](https://www.npmjs.com/package/@power-seo/preview)                   | `npm i @power-seo/preview`          | SERP, Open Graph, and Twitter/X Card preview generators                 |
+| [`@power-seo/sitemap`](https://www.npmjs.com/package/@power-seo/sitemap)                   | `npm i @power-seo/sitemap`          | XML sitemap generation, streaming, index splitting, and validation      |
+| [`@power-seo/redirects`](https://www.npmjs.com/package/@power-seo/redirects)               | `npm i @power-seo/redirects`        | Redirect engine with Next.js, Remix, and Express adapters               |
+| [`@power-seo/links`](https://www.npmjs.com/package/@power-seo/links)                       | `npm i @power-seo/links`            | Link graph analysis — orphan detection, suggestions, equity scoring     |
+| [`@power-seo/audit`](https://www.npmjs.com/package/@power-seo/audit)                       | `npm i @power-seo/audit`            | Full SEO audit engine — meta, content, structure, performance rules     |
+| [`@power-seo/images`](https://www.npmjs.com/package/@power-seo/images)                     | `npm i @power-seo/images`           | Image SEO — alt text, lazy loading, format analysis, image sitemaps     |
+| [`@power-seo/ai`](https://www.npmjs.com/package/@power-seo/ai)                             | `npm i @power-seo/ai`               | LLM-agnostic AI prompt templates and parsers for SEO tasks              |
+| [`@power-seo/analytics`](https://www.npmjs.com/package/@power-seo/analytics)               | `npm i @power-seo/analytics`        | Merge GSC + audit data, trend analysis, ranking insights, dashboard     |
+| [`@power-seo/search-console`](https://www.npmjs.com/package/@power-seo/search-console)     | `npm i @power-seo/search-console`   | Google Search Console API — OAuth2, service account, URL inspection     |
+| [`@power-seo/integrations`](https://www.npmjs.com/package/@power-seo/integrations)         | `npm i @power-seo/integrations`     | Semrush and Ahrefs API clients with rate limiting and pagination        |
+| [`@power-seo/tracking`](https://www.npmjs.com/package/@power-seo/tracking)                 | `npm i @power-seo/tracking`         | GA4, Clarity, PostHog, Plausible, Fathom — scripts + consent management |
 
 ---
 
 ## Keywords
 
-```text
-seo, react, meta-tags, open-graph, twitter-card, robots, canonical, hreflang, breadcrumb, json-ld, nextjs, gatsby, typescript, react-helmet
-```
+react seo · meta tags react · open graph react · twitter card react · react helmet alternative · next.js pages router seo · react canonical url · robots meta react · hreflang react · breadcrumb json-ld · react seo components · typescript react seo · declarative seo react · react head management · seo context react · react 19 seo · vite react seo · gatsby seo components · react open graph · react twitter card · react breadcrumb structured data · noindex react · react meta description
+
+---
+
+## About [CyberCraft Bangladesh](https://ccbd.dev)
+
+**[CyberCraft Bangladesh](https://ccbd.dev)** is a Bangladesh-based enterprise-grade software development and Full Stack SEO service provider company specializing in ERP system development, AI-powered SaaS and business applications, full-stack SEO services, custom website development, and scalable eCommerce platforms. We design and develop intelligent, automation-driven SaaS and enterprise solutions that help startups, SMEs, NGOs, educational institutes, and large organizations streamline operations, enhance digital visibility, and accelerate growth through modern cloud-native technologies.
+
+[![Website](https://img.shields.io/badge/Website-ccbd.dev-blue?style=for-the-badge)](https://ccbd.dev)
+[![GitHub](https://img.shields.io/badge/GitHub-cybercraftbd-black?style=for-the-badge&logo=github)](https://github.com/cybercraftbd)
+[![npm](https://img.shields.io/badge/npm-power--seo-red?style=for-the-badge&logo=npm)](https://www.npmjs.com/org/power-seo)
+[![Email](https://img.shields.io/badge/Email-info@ccbd.dev-green?style=for-the-badge&logo=gmail)](mailto:info@ccbd.dev)
+
+© 2026 [CyberCraft Bangladesh](https://ccbd.dev) · Released under the [MIT License](../../LICENSE)

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
   external: ['react', 'react-dom'],
 });

--- a/packages/readability/tsup.config.ts
+++ b/packages/readability/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
 });

--- a/packages/redirects/tsup.config.ts
+++ b/packages/redirects/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
 });

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1,72 +1,79 @@
-# @power-seo/schema — Type-Safe JSON-LD Structured Data for React, Next.js & Remix — 20 Builders, 18 Components, Schema Graph
+# @power-seo/schema
 
 [![npm version](https://img.shields.io/npm/v/@power-seo/schema)](https://www.npmjs.com/package/@power-seo/schema)
 [![npm downloads](https://img.shields.io/npm/dm/@power-seo/schema)](https://www.npmjs.com/package/@power-seo/schema)
+[![Socket](https://socket.dev/api/badge/npm/package/@power-seo/schema)](https://socket.dev/npm/package/@power-seo/schema)
+[![npm provenance](https://img.shields.io/badge/npm-provenance-enabled-blue)](https://github.com/CyberCraftBD/power-seo/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
 [![tree-shakeable](https://img.shields.io/badge/tree--shakeable-yes-brightgreen)](https://bundlephobia.com/package/@power-seo/schema)
 
----
+Type-safe JSON-LD structured data for TypeScript and React — 23 schema.org builder functions, 21 React components, schema graph support, and field validation. Works in Next.js, Remix, Node.js, and Edge runtimes.
 
-## Overview
+`@power-seo/schema` gives you a fully typed, builder-function API for generating Google-compliant schema.org markup — with compile-time type checking on every schema property, a `validateSchema()` utility that surfaces missing required fields before pages go live, and pre-built React components that render `<script type="application/ld+json">` tags in one line. Combine multiple schemas into a single `@graph` document via `schemaGraph()` so Google parses all of them. All 23 schema types are independently importable and tree-shakeable.
 
-**@power-seo/schema** is a type-safe JSON-LD structured data library for TypeScript developers and React teams that helps you build Google-compliant schema.org markup — with 20 builder functions, 18 pre-built React components, schema graph support, and field validation.
-
-**What it does**
-
-- ✅ **20 schema.org type builders** — Article, FAQPage, Product, LocalBusiness, Event, Recipe, HowTo, VideoObject, Course, JobPosting, and more
-- ✅ **18 ready-to-use React components** — `<ArticleJsonLd>`, `<FAQJsonLd>`, `<ProductJsonLd>`, `<BreadcrumbJsonLd>`, and more
-- ✅ **Schema graph** — combine multiple schemas into a single `@graph` document with `schemaGraph()`
-- ✅ **Field validation** — `validateSchema()` checks required fields and returns `{ valid, errors }` without throwing
-- ✅ **Safe serialization** — `toJsonLdString()` for `dangerouslySetInnerHTML`
-
-**What it is not**
-
-- ❌ **Not a Google Search Console validator** — validates field presence, not full Google Rich Results spec compliance
-- ❌ **Not a scraper** — does not fetch structured data from external pages
-
-**Recommended for**
-
-- **Next.js App Router pages**, **Remix routes**, **React SSR apps**, and **programmatic SEO sites** targeting Google rich results
+> **Zero runtime dependencies** — only `@power-seo/core` as a peer.
 
 ---
 
-## Why @power-seo/schema Matters
+## Why @power-seo/schema?
 
-**The problem**
-
-- **Hand-written JSON-LD has no type checking** — missing required fields like `datePublished` or `author` silently fail Google Rich Results
-- **Multiple schemas per page need `@graph`** — without it, Google may only process the first schema it finds
-- **Schema types differ** — Article, FAQPage, Product, LocalBusiness each have different required fields and data shapes
-
-**Why developers care**
-
-- **SEO:** Rich results (FAQ dropdowns, star ratings, breadcrumb trails) increase SERP real estate and click-through rates
-- **UX:** Rich results improve brand visibility and trust signals in search
-- **Performance:** Server-side serialized JSON-LD adds zero client-side JavaScript overhead
+| | Without | With |
+|---|---|---|
+| Field type safety | ❌ Hand-written JSON, no types | ✅ Typed builder functions catch missing fields at compile time |
+| Multiple schemas per page | ❌ Separate `<script>` tags, Google may miss some | ✅ `schemaGraph()` combines all into one `@graph` document |
+| Field validation | ❌ Silent failures in rich results | ✅ `validateSchema()` returns structured issues before deploy |
+| React rendering | ❌ Manual `dangerouslySetInnerHTML` boilerplate | ✅ `<ArticleJsonLd>` and 20 other components in one import |
+| Schema coverage | ❌ Only Article/FAQ in most packages | ✅ 23 types: Article, Product, FAQ, LocalBusiness, Event, Recipe, and more |
+| Framework support | ❌ WordPress / next-seo only | ✅ Next.js, Remix, Node.js, Edge, static site generators |
 
 ---
 
-## Key Features
+## Features
 
-- **20 schema.org type builder functions** — Article, BlogPosting, NewsArticle, Product, FAQPage, BreadcrumbList, LocalBusiness, Organization, Person, Event, Recipe, HowTo, VideoObject, Course, JobPosting, SoftwareApplication, WebSite, ItemList, Review, Service
-- **18 pre-built React components** — `<ArticleJsonLd>`, `<FAQJsonLd>`, `<ProductJsonLd>`, `<BreadcrumbJsonLd>`, `<LocalBusinessJsonLd>`, `<EventJsonLd>`, `<RecipeJsonLd>`, `<HowToJsonLd>`, `<VideoJsonLd>`, `<CourseJsonLd>`, `<JobPostingJsonLd>`, `<SoftwareAppJsonLd>`, `<WebSiteJsonLd>`, `<OrganizationJsonLd>`, `<PersonJsonLd>`, `<ItemListJsonLd>`, `<ReviewJsonLd>`, `<NewsArticleJsonLd>`
+- **23 schema.org type builder functions** — Article, BlogPosting, NewsArticle, Product, FAQPage, BreadcrumbList, LocalBusiness, Organization, Person, Event, Recipe, HowTo, VideoObject, Course, JobPosting, SoftwareApplication, WebSite, ItemList, Review, Service, Brand, SiteNavigationElement, ImageObject
+- **21 pre-built React components** — `<ArticleJsonLd>`, `<FAQJsonLd>`, `<ProductJsonLd>`, `<BreadcrumbJsonLd>`, `<LocalBusinessJsonLd>`, `<OrganizationJsonLd>`, `<PersonJsonLd>`, `<EventJsonLd>`, `<RecipeJsonLd>`, `<HowToJsonLd>`, `<VideoJsonLd>`, `<CourseJsonLd>`, `<JobPostingJsonLd>`, `<SoftwareAppJsonLd>`, `<WebSiteJsonLd>`, `<ItemListJsonLd>`, `<ReviewJsonLd>`, `<ServiceJsonLd>`, `<BrandJsonLd>`, `<NewsArticleJsonLd>`, `<BlogPostingJsonLd>`
 - **Generic `<JsonLd>` component** — renders any custom schema object as a JSON-LD script tag
 - **`schemaGraph()`** — combine multiple schemas into a single `@graph` document for optimal Google parsing
-- **`toJsonLdString()`** — serialize any schema object to a safe JSON-LD string
-- **`validateSchema()`** — validate required fields without throwing; returns `{ valid, errors }`
-- **React optional** — builder functions work without React; components available via `/react` subpath export
+- **`toJsonLdString()`** — serialize any schema object to a safe JSON-LD string for `dangerouslySetInnerHTML`
+- **`validateSchema()`** — validate required fields without throwing; returns `{ valid, issues }` with severity, field, and message per issue
+- **React optional** — all 23 builder functions work without React; components available via `/react` subpath export
 - **Type-safe API** — TypeScript-first with full typed interfaces for every schema type including nested objects
-- **Tree-shakeable** — import only the schema types you use
+- **Tree-shakeable** — import only the schema types you use; zero dead code in your bundle
+- **Dual ESM + CJS** — ships both formats via tsup for any bundler or `require()` usage
 
 ---
 
-## Benefits of Using @power-seo/schema
+## Comparison
 
-- **Improved rich result eligibility**: Typed builder functions surface missing required fields at compile time
-- **Better SERP visibility**: FAQ dropdowns, product ratings, breadcrumb trails, and job listings in search results
-- **Safer implementation**: `validateSchema()` catches missing fields in CI before pages are published
-- **Faster delivery**: React components render JSON-LD in one line; no hand-coding script tags
+| Feature                        | @power-seo/schema | next-seo | schema-dts | json-ld.js | react-schemaorg |
+| ------------------------------ | :---------------: | :------: | :--------: | :--------: | :-------------: |
+| Typed builder functions        | ✅                | Partial  | ❌         | ❌         | ❌              |
+| Ready-to-use React components  | ✅                | ✅       | ❌         | ❌         | Partial         |
+| `@graph` support               | ✅                | ❌       | ❌         | ✅         | ❌              |
+| Built-in field validation      | ✅                | ❌       | ❌         | ❌         | ❌              |
+| Works without React            | ✅                | ❌       | ✅         | ✅         | ❌              |
+| 23 schema types                | ✅                | Partial  | ✅         | ✅         | ❌              |
+| CI / Node.js usage             | ✅                | ❌       | ✅         | ✅         | ❌              |
+| Zero runtime dependencies      | ✅                | ❌       | ✅         | ❌         | ❌              |
+| TypeScript-first               | ✅                | Partial  | ✅         | ❌         | ❌              |
+| Tree-shakeable                 | ✅                | ❌       | ✅         | ❌         | ❌              |
+
+---
+
+## Installation
+
+```bash
+npm install @power-seo/schema
+```
+
+```bash
+yarn add @power-seo/schema
+```
+
+```bash
+pnpm add @power-seo/schema
+```
 
 ---
 
@@ -76,7 +83,7 @@
 // Builder function approach (works without React)
 import { article, toJsonLdString } from '@power-seo/schema';
 
-const jsonLd = article({
+const schema = article({
   headline: 'My Blog Post',
   description: 'An informative article about SEO.',
   datePublished: '2026-01-15',
@@ -85,7 +92,7 @@ const jsonLd = article({
   image: { url: 'https://example.com/article-cover.jpg', width: 1200, height: 630 },
 });
 
-const script = toJsonLdString(jsonLd);
+const script = toJsonLdString(schema);
 // → '{"@context":"https://schema.org","@type":"Article","headline":"My Blog Post",...}'
 ```
 
@@ -99,291 +106,364 @@ import { ArticleJsonLd } from '@power-seo/schema/react';
   datePublished="2026-01-15"
   author={{ name: 'Jane Doe', url: 'https://example.com/authors/jane-doe' }}
   image={{ url: 'https://example.com/cover.jpg', width: 1200, height: 630 }}
-/>;
+/>
 // Renders: <script type="application/ld+json">{"@context":"https://schema.org",...}</script>
 ```
 
-**What you should see**
-
-- A `<script type="application/ld+json">` tag in the page `<head>` with valid schema.org JSON
-- `validateSchema(schema).valid === true` for fully populated schemas
-
 ---
 
-## Installation
+## Usage
 
-```bash
-npm i @power-seo/schema
-# or
-yarn add @power-seo/schema
-# or
-pnpm add @power-seo/schema
-# or
-bun add @power-seo/schema
+### Builder Functions (No React Required)
+
+Call any builder function with a typed props object to produce a schema-ready JSON-LD object, then pass it to `toJsonLdString()` for serialization or `schemaGraph()` to combine with other schemas.
+
+```ts
+import { product, toJsonLdString } from '@power-seo/schema';
+
+const schema = product({
+  name: 'Wireless Headphones',
+  description: 'Premium noise-cancelling headphones.',
+  image: { url: 'https://example.com/headphones.jpg' },
+  offers: {
+    price: 149.99,
+    priceCurrency: 'USD',
+    availability: 'InStock',
+  },
+  aggregateRating: {
+    ratingValue: 4.7,
+    reviewCount: 312,
+  },
+});
+
+console.log(toJsonLdString(schema));
+```
+
+### React Components
+
+Import from the `/react` entry point for pre-built JSON-LD components that render `<script type="application/ld+json">` tags:
+
+```tsx
+import { FAQJsonLd, BreadcrumbJsonLd } from '@power-seo/schema/react';
+
+function PageHead() {
+  return (
+    <>
+      <FAQJsonLd
+        questions={[
+          { question: 'What is JSON-LD?', answer: 'A structured data format used by Google.' },
+          { question: 'Do I need React?', answer: 'No — builder functions work without React.' },
+        ]}
+      />
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', url: 'https://example.com' },
+          { name: 'Blog', url: 'https://example.com/blog' },
+          { name: 'My Post' },
+        ]}
+      />
+    </>
+  );
+}
+```
+
+### Schema Graph (Multiple Schemas Per Page)
+
+Use `schemaGraph()` to combine multiple schema objects into a single `@graph` document. This ensures Google parses all schemas on the page, not just the first `<script>` tag it finds.
+
+```ts
+import { article, breadcrumbList, organization, schemaGraph, toJsonLdString } from '@power-seo/schema';
+
+const graph = schemaGraph([
+  article({ headline: 'My Post', datePublished: '2026-01-01', author: { name: 'Jane Doe' } }),
+  breadcrumbList([
+    { name: 'Home', url: 'https://example.com' },
+    { name: 'Blog', url: 'https://example.com/blog' },
+    { name: 'My Post' },
+  ]),
+  organization({ name: 'Acme Corp', url: 'https://example.com' }),
+]);
+
+const script = toJsonLdString(graph);
+// → '{"@context":"https://schema.org","@graph":[{...},{...},{...}]}'
+```
+
+### Field Validation
+
+`validateSchema()` checks required fields and returns a structured result without throwing. Use it in CI pipelines to catch missing fields before pages are published.
+
+```ts
+import { article, validateSchema } from '@power-seo/schema';
+
+const schema = article({ headline: 'Incomplete Article' }); // missing datePublished, author
+
+const result = validateSchema(schema);
+// result.valid → false
+// result.issues → [
+//   { severity: 'error', field: 'datePublished', message: 'datePublished is required for Article' },
+//   { severity: 'error', field: 'author', message: 'author is required for Article' },
+// ]
+
+if (!result.valid) {
+  const errors = result.issues.filter((i) => i.severity === 'error');
+  console.error(`${errors.length} validation error(s) found`);
+  errors.forEach((i) => console.error(` ✗ [${i.field}] ${i.message}`));
+  process.exit(1);
+}
+```
+
+### FAQ and Breadcrumb Builder Signatures
+
+`faqPage()` and `breadcrumbList()` accept plain arrays directly — not a config object wrapper:
+
+```ts
+import { faqPage, breadcrumbList } from '@power-seo/schema';
+
+// faqPage takes a plain array of { question, answer } items
+const faq = faqPage([
+  { question: 'What is schema.org?', answer: 'A shared vocabulary for structured data.' },
+  { question: 'Does Google require JSON-LD?', answer: 'JSON-LD is the recommended format.' },
+]);
+
+// breadcrumbList takes a plain array of { name, url? } items
+const breadcrumb = breadcrumbList([
+  { name: 'Home', url: 'https://example.com' },
+  { name: 'Products', url: 'https://example.com/products' },
+  { name: 'Headphones' },
+]);
+```
+
+### Next.js App Router
+
+Use builder functions in `page.tsx` to generate JSON-LD for server-side rendering:
+
+```tsx
+import { article, toJsonLdString } from '@power-seo/schema';
+
+export default function BlogPost({ post }: { post: Post }) {
+  const schema = article({
+    headline: post.title,
+    description: post.excerpt,
+    datePublished: post.publishedAt,
+    dateModified: post.updatedAt,
+    author: { name: post.author.name, url: post.author.profileUrl },
+    image: { url: post.coverImage, width: 1200, height: 630 },
+  });
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: toJsonLdString(schema) }}
+      />
+      <article>{/* page content */}</article>
+    </>
+  );
+}
+```
+
+### CI Validation Gate
+
+Block deploys when schema validation fails:
+
+```ts
+import { validateSchema } from '@power-seo/schema';
+import { allPageSchemas } from './build-schemas';
+
+for (const schema of allPageSchemas) {
+  const result = validateSchema(schema);
+  if (!result.valid) {
+    const errors = result.issues.filter((i) => i.severity === 'error');
+    if (errors.length > 0) {
+      console.error('Schema validation failed:');
+      errors.forEach((i) => console.error(` ✗ [${i.field}] ${i.message}`));
+      process.exit(1);
+    }
+  }
+}
 ```
 
 ---
 
-## Framework Compatibility
+## API Reference
 
-**Supported**
+### Entry Points
 
-- ✅ Next.js App Router — use builder functions in `page.tsx`, pass `toJsonLdString()` to `dangerouslySetInnerHTML`
-- ✅ Next.js Pages Router — use React components or builder functions in `getServerSideProps`
-- ✅ Remix — use builder functions in loaders; render in route components
-- ✅ Node.js 18+ — pure TypeScript, no DOM required for builder functions
-- ✅ Static site generators — generate JSON-LD at build time
+| Import | Description |
+| --- | --- |
+| `@power-seo/schema` | Builder functions, utilities, and TypeScript types |
+| `@power-seo/schema/react` | React components for rendering JSON-LD script tags |
 
-**Environment notes**
+### Builder Functions
 
-- **SSR/SSG:** Fully supported — JSON-LD is serialized server-side
-- **Edge runtime:** Builder functions and utilities supported; React components require React runtime
-- **Browser-only usage:** Supported for React components; not recommended for builder functions alone
+| Function | Schema `@type` | Rich Result Eligible |
+| --- | --- | --- |
+| `article(props)` | `Article` | Yes — Article rich results |
+| `blogPosting(props)` | `BlogPosting` | Yes — Article rich results |
+| `newsArticle(props)` | `NewsArticle` | Yes — Top Stories |
+| `product(props)` | `Product` | Yes — Product rich results |
+| `faqPage(questions)` | `FAQPage` | Yes — FAQ rich results |
+| `breadcrumbList(items)` | `BreadcrumbList` | Yes — Breadcrumbs in SERP |
+| `localBusiness(props)` | `LocalBusiness` | Yes — Local Business panel |
+| `organization(props)` | `Organization` | Yes — Knowledge Panel |
+| `person(props)` | `Person` | Yes — Knowledge Panel |
+| `event(props)` | `Event` | Yes — Event rich results |
+| `recipe(props)` | `Recipe` | Yes — Recipe rich results |
+| `howTo(props)` | `HowTo` | Yes — How-to rich results |
+| `videoObject(props)` | `VideoObject` | Yes — Video rich results |
+| `course(props)` | `Course` | Yes — Course rich results |
+| `jobPosting(props)` | `JobPosting` | Yes — Job Posting results |
+| `softwareApp(props)` | `SoftwareApplication` | Yes — App rich results |
+| `webSite(props)` | `WebSite` | Yes — Sitelinks Searchbox |
+| `itemList(props)` | `ItemList` | Yes — Carousel results |
+| `review(props)` | `Review` | Yes — Review snippet |
+| `service(props)` | `Service` | Partial |
+| `brand(props)` | `Brand` | Partial |
+| `siteNavigationElement(props)` | `SiteNavigationElement` | Partial |
+| `imageObject(props)` | `ImageObject` | Yes — Image rich results |
+
+### Utility Functions
+
+| Function | Signature | Description |
+| --- | --- | --- |
+| `toJsonLdString` | `(schema: object, pretty?: boolean) => string` | Serialize schema to safe JSON-LD string |
+| `schemaGraph` | `(schemas: object[]) => object` | Combine schemas into a single `@graph` document |
+| `validateSchema` | `(schema: object) => { valid: boolean; issues: ValidationIssue[] }` | Validate required fields; returns structured issues |
+
+### React Components
+
+Import all components from `@power-seo/schema/react`.
+
+| Component | Props | Description |
+| --- | --- | --- |
+| `<ArticleJsonLd>` | `Omit<ArticleSchema, '@type' \| '@context'>` | Article schema |
+| `<BlogPostingJsonLd>` | `Omit<ArticleSchema, '@type' \| '@context'>` | BlogPosting schema |
+| `<NewsArticleJsonLd>` | `Omit<ArticleSchema, '@type' \| '@context'>` | NewsArticle schema for Top Stories |
+| `<ProductJsonLd>` | `Omit<ProductSchema, '@type' \| '@context'>` | Product with offers and ratings |
+| `<FAQJsonLd>` | `{ questions: Array<{ question: string; answer: string }> }` | FAQPage schema |
+| `<BreadcrumbJsonLd>` | `{ items: Array<{ name: string; url?: string }> }` | BreadcrumbList schema |
+| `<LocalBusinessJsonLd>` | `Omit<LocalBusinessSchema, '@type' \| '@context'>` | LocalBusiness schema |
+| `<OrganizationJsonLd>` | `Omit<OrganizationSchema, '@type' \| '@context'>` | Organization schema |
+| `<PersonJsonLd>` | `Omit<PersonSchema, '@type' \| '@context'>` | Person schema |
+| `<EventJsonLd>` | `Omit<EventSchema, '@type' \| '@context'>` | Event schema |
+| `<RecipeJsonLd>` | `Omit<RecipeSchema, '@type' \| '@context'>` | Recipe schema |
+| `<HowToJsonLd>` | `Omit<HowToSchema, '@type' \| '@context'>` | HowTo schema |
+| `<VideoJsonLd>` | `Omit<VideoObjectSchema, '@type' \| '@context'>` | VideoObject schema |
+| `<CourseJsonLd>` | `Omit<CourseSchema, '@type' \| '@context'>` | Course schema |
+| `<JobPostingJsonLd>` | `Omit<JobPostingSchema, '@type' \| '@context'>` | JobPosting schema |
+| `<SoftwareAppJsonLd>` | `Omit<SoftwareAppSchema, '@type' \| '@context'>` | SoftwareApplication schema |
+| `<WebSiteJsonLd>` | `Omit<WebSiteSchema, '@type' \| '@context'>` | WebSite with SearchAction |
+| `<ItemListJsonLd>` | `Omit<ItemListSchema, '@type' \| '@context'>` | ItemList schema |
+| `<ReviewJsonLd>` | `Omit<ReviewSchema, '@type' \| '@context'>` | Review schema |
+| `<ServiceJsonLd>` | `Omit<ServiceSchema, '@type' \| '@context'>` | Service schema |
+| `<BrandJsonLd>` | `Omit<BrandSchema, '@type' \| '@context'>` | Brand schema |
+| `<JsonLd>` | `{ schema: object }` | Generic — any schema object |
+
+### Types
+
+| Type | Description |
+| --- | --- |
+| `ArticleSchema` | Props for Article, BlogPosting, and NewsArticle builder functions |
+| `ProductSchema` | Props for `product()` builder |
+| `FAQPageSchema` | Output type of `faqPage()` |
+| `BreadcrumbListSchema` | Output type of `breadcrumbList()` |
+| `LocalBusinessSchema` | Props for `localBusiness()` builder |
+| `OrganizationSchema` | Props for `organization()` builder |
+| `PersonSchema` | Props for `person()` builder |
+| `EventSchema` | Props for `event()` builder |
+| `RecipeSchema` | Props for `recipe()` builder |
+| `HowToSchema` | Props for `howTo()` builder |
+| `VideoObjectSchema` | Props for `videoObject()` builder |
+| `CourseSchema` | Props for `course()` builder |
+| `JobPostingSchema` | Props for `jobPosting()` builder |
+| `SoftwareAppSchema` | Props for `softwareApp()` builder |
+| `WebSiteSchema` | Props for `webSite()` builder |
+| `ItemListSchema` | Props for `itemList()` builder |
+| `ReviewSchema` | Props for `review()` builder |
+| `ServiceSchema` | Props for `service()` builder |
+| `BrandSchema` | Props for `brand()` builder |
+| `ValidationIssue` | `{ severity: 'error' \| 'warning'; field: string; message: string }` |
 
 ---
 
 ## Use Cases
 
-- **Blog posts and articles** — Article/BlogPosting schema for Google Discover and Top Stories eligibility
-- **FAQ pages** — FAQPage schema for FAQ dropdown rich results
-- **Product pages** — Product schema with offers and aggregate ratings for product rich results
+- **Blog posts and articles** — Article and BlogPosting schema for Google Discover and Top Stories eligibility
+- **FAQ pages** — FAQPage schema for FAQ accordion rich results in SERPs
+- **Product pages** — Product schema with offers and aggregate ratings for product rich results and star display
 - **Local business sites** — LocalBusiness schema for Google Business Panel and Local Pack
 - **Recipe sites** — Recipe schema for rich cards with images, ratings, and cooking time
 - **Job boards** — JobPosting schema for Google for Jobs integration
 - **Event pages** — Event schema for Google Events rich results
 - **Course platforms** — Course schema for education carousels in Google Search
 - **Software landing pages** — SoftwareApplication schema for app details in results
-
----
-
-## Example (Before / After)
-
-```text
-Before:
-- Hand-written JSON-LD: missing "datePublished" → Article not eligible for rich results
-- Multiple schemas in separate <script> tags → Google may only parse the first one
-- No TypeScript types → runtime errors when API data shape changes
-
-After (@power-seo/schema):
-- article({ headline, datePublished, author }) → TypeScript flags missing required fields
-- schemaGraph([article, breadcrumb, org]) → single @graph document, all schemas parsed
-- validateSchema(schema).errors → ['Article: datePublished is required'] caught in CI
-```
-
----
-
-## Implementation Best Practices
-
-- **Always use `schemaGraph()`** when rendering multiple schemas on the same page
-- **Validate in CI** with `validateSchema()` — catch missing required fields before deploying
-- **Use `toJsonLdString()` for `dangerouslySetInnerHTML`** — avoids double-encoding issues
-- **Include `publisher` on Article schemas** — required for Google News eligibility
-- **Set `aggregateRating.reviewCount`** on Product schemas — minimum threshold for star display
+- **Multi-schema pages** — `schemaGraph()` to combine Article + Breadcrumb + Organization into a single `@graph`
+- **CI content pipelines** — `validateSchema()` to block deploys when required fields are missing
 
 ---
 
 ## Architecture Overview
 
-**Where it runs**
-
-- **Build-time**: Generate and validate JSON-LD for all static pages; fail CI on validation errors
-- **Runtime**: Builder functions in SSR routes produce JSON-LD for each request
-- **CI/CD**: Run `validateSchema()` across all schema outputs in pull request checks
-
-**Data flow**
-
-1. **Input**: Typed config objects (article config, FAQ questions, product offers, etc.)
-2. **Analysis**: Builder function assembles `@context`, `@type`, and typed properties
-3. **Output**: JSON-LD object or serialized string embedded in `<script type="application/ld+json">`
-4. **Action**: Google parses schema, evaluates eligibility for rich results in SERP
+- **Pure TypeScript** — no compiled binary, no native modules
+- **Zero runtime dependencies** — only `@power-seo/core` as a peer dependency
+- **Framework-agnostic** — builder functions work in any JavaScript environment with no DOM requirement
+- **SSR compatible** — safe to run in Next.js Server Components, Remix loaders, or Express handlers
+- **Edge runtime safe** — no Node.js-specific APIs; builder functions run in Cloudflare Workers, Vercel Edge, Deno
+- **Tree-shakeable** — `"sideEffects": false` with named exports per schema type
+- **Dual ESM + CJS** — ships both formats via tsup for any bundler or `require()` usage
 
 ---
 
-## Features Comparison with Popular Packages
+## Supply Chain Security
 
-| Capability                    |     next-seo | schema-dts | json-ld | @power-seo/schema |
-| ----------------------------- | -----------: | ---------: | ------: | ----------------: |
-| Typed builder functions       |           ✅ |         ❌ |      ❌ |                ✅ |
-| Ready-to-use React components |           ✅ |         ❌ |      ❌ |                ✅ |
-| `@graph` support              |           ❌ |         ❌ |      ❌ |                ✅ |
-| Built-in field validation     |           ❌ |         ❌ |      ❌ |                ✅ |
-| Works without React           |           ❌ |         ✅ |      ✅ |                ✅ |
-| 20+ schema types              | ❌ (partial) |         ✅ |      ✅ |                ✅ |
+- No install scripts (`postinstall`, `preinstall`)
+- No runtime network access
+- No `eval` or dynamic code execution
+- npm provenance enabled — every release is signed via Sigstore through GitHub Actions
+- CI-signed builds — all releases published via verified `github.com/CyberCraftBD/power-seo` workflow
+- Safe for SSR, Edge, and server environments
 
 ---
 
-## [@power-seo](https://www.npmjs.com/org/power-seo) Ecosystem
+## The [@power-seo](https://www.npmjs.com/org/power-seo) Ecosystem
 
 All 17 packages are independently installable — use only what you need.
 
-| Package                                                                                    | Install                             | Description                                                                |
-| ------------------------------------------------------------------------------------------ | ----------------------------------- | -------------------------------------------------------------------------- |
-| [`@power-seo/core`](https://www.npmjs.com/package/@power-seo/core)                         | `npm i @power-seo/core`             | Framework-agnostic utilities, types, validators, and constants             |
-| [`@power-seo/react`](https://www.npmjs.com/package/@power-seo/react)                       | `npm i @power-seo/react`            | React SEO components — meta, Open Graph, Twitter Card, robots, breadcrumbs |
-| [`@power-seo/meta`](https://www.npmjs.com/package/@power-seo/meta)                         | `npm i @power-seo/meta`             | SSR meta helpers for Next.js App Router, Remix v2, and generic SSR         |
-| [`@power-seo/schema`](https://www.npmjs.com/package/@power-seo/schema)                     | `npm i @power-seo/schema`           | Type-safe JSON-LD structured data — 20 builders + 18 React components      |
-| [`@power-seo/content-analysis`](https://www.npmjs.com/package/@power-seo/content-analysis) | `npm i @power-seo/content-analysis` | Yoast-style SEO content scoring engine with React components               |
-| [`@power-seo/readability`](https://www.npmjs.com/package/@power-seo/readability)           | `npm i @power-seo/readability`      | Readability scoring — Flesch-Kincaid, Gunning Fog, Coleman-Liau, ARI       |
-| [`@power-seo/preview`](https://www.npmjs.com/package/@power-seo/preview)                   | `npm i @power-seo/preview`          | SERP, Open Graph, and Twitter/X Card preview generators                    |
-| [`@power-seo/sitemap`](https://www.npmjs.com/package/@power-seo/sitemap)                   | `npm i @power-seo/sitemap`          | XML sitemap generation, streaming, index splitting, and validation         |
-| [`@power-seo/redirects`](https://www.npmjs.com/package/@power-seo/redirects)               | `npm i @power-seo/redirects`        | Redirect engine with Next.js, Remix, and Express adapters                  |
-| [`@power-seo/links`](https://www.npmjs.com/package/@power-seo/links)                       | `npm i @power-seo/links`            | Link graph analysis — orphan detection, suggestions, equity scoring        |
-| [`@power-seo/audit`](https://www.npmjs.com/package/@power-seo/audit)                       | `npm i @power-seo/audit`            | Full SEO audit engine — meta, content, structure, performance rules        |
-| [`@power-seo/images`](https://www.npmjs.com/package/@power-seo/images)                     | `npm i @power-seo/images`           | Image SEO — alt text, lazy loading, format analysis, image sitemaps        |
-| [`@power-seo/ai`](https://www.npmjs.com/package/@power-seo/ai)                             | `npm i @power-seo/ai`               | LLM-agnostic AI prompt templates and parsers for SEO tasks                 |
-| [`@power-seo/analytics`](https://www.npmjs.com/package/@power-seo/analytics)               | `npm i @power-seo/analytics`        | Merge GSC + audit data, trend analysis, ranking insights, dashboard        |
-| [`@power-seo/search-console`](https://www.npmjs.com/package/@power-seo/search-console)     | `npm i @power-seo/search-console`   | Google Search Console API — OAuth2, service account, URL inspection        |
-| [`@power-seo/integrations`](https://www.npmjs.com/package/@power-seo/integrations)         | `npm i @power-seo/integrations`     | Semrush and Ahrefs API clients with rate limiting and pagination           |
-| [`@power-seo/tracking`](https://www.npmjs.com/package/@power-seo/tracking)                 | `npm i @power-seo/tracking`         | GA4, Clarity, PostHog, Plausible, Fathom — scripts + consent management    |
-
-### Ecosystem vs alternatives
-
-| Need                    | Common approach            | @power-seo approach                       |
-| ----------------------- | -------------------------- | ----------------------------------------- |
-| JSON-LD structured data | `next-seo` (limited types) | `@power-seo/schema` — 20 types + graph    |
-| React components        | Manual `<script>` tags     | `@power-seo/schema/react` — 18 components |
-| Meta tags               | `react-helmet`             | `@power-seo/react` + `@power-seo/meta`    |
-| Sitemap                 | `next-sitemap`             | `@power-seo/sitemap` — streaming + index  |
-
----
-
-## Enterprise Integration
-
-**Multi-tenant SaaS**
-
-- **Tenant-aware schemas**: Inject tenant `organization` into every page's `@graph` dynamically
-- **Per-page schema pipelines**: Generate and validate schemas in CI for all content types
-- **Compliance**: `validateSchema()` ensures no rich result opportunities are silently missed
-
-**ERP / internal portals**
-
-- Add `Organization` schema to public-facing portals for Knowledge Panel eligibility
-- Use `BreadcrumbList` schema on all navigable public pages
-- Validate schemas as part of the release pipeline
-
-**Recommended integration pattern**
-
-- Run `validateSchema()` in **CI** for all schema objects
-- Fail build on `valid === false` for Article, Product, and FAQ schemas
-- Track rich result status in **Google Search Console** after deployment
-
----
-
-## Scope and Limitations
-
-**This package does**
-
-- ✅ Build typed JSON-LD objects for 20 schema.org types
-- ✅ Render JSON-LD `<script>` tags via 18 React components
-- ✅ Validate required fields and return structured errors
-- ✅ Combine multiple schemas into a single `@graph` document
-
-**This package does not**
-
-- ❌ Guarantee Google Rich Results eligibility (Google's spec changes independently)
-- ❌ Fetch schema data from live pages
-- ❌ Submit schemas to Google directly — use Google Search Console for testing
-
----
-
-## API Reference
-
-### Builder Functions
-
-| Function                      | Schema `@type`        | Rich Result Eligible       |
-| ----------------------------- | --------------------- | -------------------------- |
-| `article(config)`             | `Article`             | Yes — Article rich results |
-| `blogPosting(config)`         | `BlogPosting`         | Yes — Article rich results |
-| `newsArticle(config)`         | `NewsArticle`         | Yes — Top Stories          |
-| `faqPage(config)`             | `FAQPage`             | Yes — FAQ rich results     |
-| `product(config)`             | `Product`             | Yes — Product rich results |
-| `breadcrumbList(config)`      | `BreadcrumbList`      | Yes — Breadcrumbs in SERP  |
-| `localBusiness(config)`       | `LocalBusiness`       | Yes — Local Business panel |
-| `organization(config)`        | `Organization`        | Yes — Knowledge Panel      |
-| `person(config)`              | `Person`              | Yes — Knowledge Panel      |
-| `event(config)`               | `Event`               | Yes — Event rich results   |
-| `recipe(config)`              | `Recipe`              | Yes — Recipe rich results  |
-| `howTo(config)`               | `HowTo`               | Yes — How-to rich results  |
-| `videoObject(config)`         | `VideoObject`         | Yes — Video rich results   |
-| `course(config)`              | `Course`              | Yes — Course rich results  |
-| `jobPosting(config)`          | `JobPosting`          | Yes — Job Posting results  |
-| `softwareApplication(config)` | `SoftwareApplication` | Yes — App rich results     |
-| `webSite(config)`             | `WebSite`             | Yes — Sitelinks Searchbox  |
-| `itemList(config)`            | `ItemList`            | Yes — Carousel results     |
-| `review(config)`              | `Review`              | Yes — Review snippet       |
-| `service(config)`             | `Service`             | Partial                    |
-
-### React Components
-
-| Component               | Prop Type                     | Description                        |
-| ----------------------- | ----------------------------- | ---------------------------------- |
-| `<ArticleJsonLd>`       | `ArticleConfig`               | Article / BlogPosting schema       |
-| `<NewsArticleJsonLd>`   | `NewsArticleConfig`           | NewsArticle schema for Top Stories |
-| `<FAQJsonLd>`           | `{ questions: FAQItem[] }`    | FAQPage schema                     |
-| `<ProductJsonLd>`       | `ProductConfig`               | Product with offers and ratings    |
-| `<BreadcrumbJsonLd>`    | `{ items: BreadcrumbItem[] }` | BreadcrumbList schema              |
-| `<LocalBusinessJsonLd>` | `LocalBusinessConfig`         | LocalBusiness schema               |
-| `<OrganizationJsonLd>`  | `OrganizationConfig`          | Organization schema                |
-| `<PersonJsonLd>`        | `PersonConfig`                | Person schema                      |
-| `<EventJsonLd>`         | `EventConfig`                 | Event schema                       |
-| `<RecipeJsonLd>`        | `RecipeConfig`                | Recipe schema                      |
-| `<HowToJsonLd>`         | `HowToConfig`                 | HowTo schema                       |
-| `<VideoJsonLd>`         | `VideoObjectConfig`           | VideoObject schema                 |
-| `<CourseJsonLd>`        | `CourseConfig`                | Course schema                      |
-| `<JobPostingJsonLd>`    | `JobPostingConfig`            | JobPosting schema                  |
-| `<SoftwareAppJsonLd>`   | `SoftwareApplicationConfig`   | SoftwareApplication schema         |
-| `<WebSiteJsonLd>`       | `WebSiteConfig`               | WebSite with SearchAction          |
-| `<ItemListJsonLd>`      | `ItemListConfig`              | ItemList schema                    |
-| `<ReviewJsonLd>`        | `ReviewConfig`                | Review schema                      |
-| `<JsonLd>`              | `{ schema: object }`          | Generic — any schema object        |
-
-### Utilities
-
-| Function         | Signature                                                  | Description                             |
-| ---------------- | ---------------------------------------------------------- | --------------------------------------- |
-| `toJsonLdString` | `(schema: object) => string`                               | Serialize schema to safe JSON-LD string |
-| `schemaGraph`    | `(schemas: object[]) => object`                            | Combine schemas into `@graph` document  |
-| `validateSchema` | `(schema: object) => { valid: boolean; errors: string[] }` | Validate required fields                |
-
----
-
-## Contributing
-
-- Issues: [github.com/cybercraftbd/power-seo/issues](https://github.com/cybercraftbd/power-seo/issues)
-- PRs: [github.com/cybercraftbd/power-seo/pulls](https://github.com/cybercraftbd/power-seo/pulls)
-- Development setup:
-  1. `pnpm i`
-  2. `pnpm build`
-  3. `pnpm test`
-
-**Release workflow**
-
-- `npm version patch|minor|major`
-- `npm publish --access public`
-
----
-
-## About [CyberCraft Bangladesh](https://ccbd.dev)
-
-**[CyberCraft Bangladesh](https://ccbd.dev)** is a Bangladesh-based enterprise-grade software engineering company specializing in ERP system development, AI-powered SaaS and business applications, full-stack SEO services, custom website development, and scalable eCommerce platforms. We design and develop intelligent, automation-driven SaaS and enterprise solutions that help startups, SMEs, NGOs, educational institutes, and large organizations streamline operations, enhance digital visibility, and accelerate growth through modern cloud-native technologies.
-
-|                      |                                                                |
-| -------------------- | -------------------------------------------------------------- |
-| **Website**          | [ccbd.dev](https://ccbd.dev)                                   |
-| **GitHub**           | [github.com/cybercraftbd](https://github.com/cybercraftbd)     |
-| **npm Organization** | [npmjs.com/org/power-seo](https://www.npmjs.com/org/power-seo) |
-| **Email**            | [info@ccbd.dev](mailto:info@ccbd.dev)                          |
-
----
-
-## License
-
-**MIT**
+| Package | Install | Description |
+| --- | --- | --- |
+| [`@power-seo/core`](https://www.npmjs.com/package/@power-seo/core) | `npm i @power-seo/core` | Framework-agnostic utilities, types, validators, and constants |
+| [`@power-seo/react`](https://www.npmjs.com/package/@power-seo/react) | `npm i @power-seo/react` | React SEO components — meta, Open Graph, Twitter Card, breadcrumbs |
+| [`@power-seo/meta`](https://www.npmjs.com/package/@power-seo/meta) | `npm i @power-seo/meta` | SSR meta helpers for Next.js App Router, Remix v2, and generic SSR |
+| [`@power-seo/schema`](https://www.npmjs.com/package/@power-seo/schema) | `npm i @power-seo/schema` | Type-safe JSON-LD structured data — 23 builders + 21 React components |
+| [`@power-seo/content-analysis`](https://www.npmjs.com/package/@power-seo/content-analysis) | `npm i @power-seo/content-analysis` | Yoast-style SEO content scoring engine with React components |
+| [`@power-seo/readability`](https://www.npmjs.com/package/@power-seo/readability) | `npm i @power-seo/readability` | Readability scoring — Flesch-Kincaid, Gunning Fog, Coleman-Liau, ARI |
+| [`@power-seo/preview`](https://www.npmjs.com/package/@power-seo/preview) | `npm i @power-seo/preview` | SERP, Open Graph, and Twitter/X Card preview generators |
+| [`@power-seo/sitemap`](https://www.npmjs.com/package/@power-seo/sitemap) | `npm i @power-seo/sitemap` | XML sitemap generation, streaming, index splitting, and validation |
+| [`@power-seo/redirects`](https://www.npmjs.com/package/@power-seo/redirects) | `npm i @power-seo/redirects` | Redirect engine with Next.js, Remix, and Express adapters |
+| [`@power-seo/links`](https://www.npmjs.com/package/@power-seo/links) | `npm i @power-seo/links` | Link graph analysis — orphan detection, suggestions, equity scoring |
+| [`@power-seo/audit`](https://www.npmjs.com/package/@power-seo/audit) | `npm i @power-seo/audit` | Full SEO audit engine — meta, content, structure, performance rules |
+| [`@power-seo/images`](https://www.npmjs.com/package/@power-seo/images) | `npm i @power-seo/images` | Image SEO — alt text, lazy loading, format analysis, image sitemaps |
+| [`@power-seo/ai`](https://www.npmjs.com/package/@power-seo/ai) | `npm i @power-seo/ai` | LLM-agnostic AI prompt templates and parsers for SEO tasks |
+| [`@power-seo/analytics`](https://www.npmjs.com/package/@power-seo/analytics) | `npm i @power-seo/analytics` | Merge GSC + audit data, trend analysis, ranking insights, dashboard |
+| [`@power-seo/search-console`](https://www.npmjs.com/package/@power-seo/search-console) | `npm i @power-seo/search-console` | Google Search Console API — OAuth2, service account, URL inspection |
+| [`@power-seo/integrations`](https://www.npmjs.com/package/@power-seo/integrations) | `npm i @power-seo/integrations` | Semrush and Ahrefs API clients with rate limiting and pagination |
+| [`@power-seo/tracking`](https://www.npmjs.com/package/@power-seo/tracking) | `npm i @power-seo/tracking` | GA4, Clarity, PostHog, Plausible, Fathom — scripts + consent management |
 
 ---
 
 ## Keywords
 
-```text
-seo, json-ld, structured-data, schema-org, rich-results, typescript, react, nextjs, remix, faq-schema, product-schema, article-schema, local-business, breadcrumb
-```
+json-ld structured data · schema.org typescript · rich results seo · next.js json-ld · react structured data · faq schema · product schema · article schema · breadcrumb schema · local business schema · schema graph · validate schema · seo schema builder · typescript json-ld · nextjs schema · remix seo · job posting schema · event schema · recipe schema · seo rich results · structured data react · schema.org builder · programmatic seo
+
+---
+
+## About [CyberCraft Bangladesh](https://ccbd.dev)
+
+**[CyberCraft Bangladesh](https://ccbd.dev)** is a Bangladesh-based enterprise-grade software development and Full Stack SEO service provider company specializing in ERP system development, AI-powered SaaS and business applications, full-stack SEO services, custom website development, and scalable eCommerce platforms. We design and develop intelligent, automation-driven SaaS and enterprise solutions that help startups, SMEs, NGOs, educational institutes, and large organizations streamline operations, enhance digital visibility, and accelerate growth through modern cloud-native technologies.
+
+[![Website](https://img.shields.io/badge/Website-ccbd.dev-blue?style=for-the-badge)](https://ccbd.dev)
+[![GitHub](https://img.shields.io/badge/GitHub-cybercraftbd-black?style=for-the-badge&logo=github)](https://github.com/cybercraftbd)
+[![npm](https://img.shields.io/badge/npm-power--seo-red?style=for-the-badge&logo=npm)](https://www.npmjs.com/org/power-seo)
+[![Email](https://img.shields.io/badge/Email-info@ccbd.dev-green?style=for-the-badge&logo=gmail)](mailto:info@ccbd.dev)
+
+© 2026 [CyberCraft Bangladesh](https://ccbd.dev) · Released under the [MIT License](../../LICENSE)

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@power-seo/schema",
   "version": "1.0.3",
-  "description": "Type-safe JSON-LD structured data builder with 25+ schema types and React components",
+  "description": "Type-safe JSON-LD structured data builder with 23 schema builders and React components",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/schema/src/builders.ts
+++ b/packages/schema/src/builders.ts
@@ -23,6 +23,9 @@ import type {
   ItemListSchema,
   ReviewSchema,
   ServiceSchema,
+  BrandSchema,
+  SiteNavigationElementSchema,
+  ImageObject,
   SchemaGraph,
   SchemaObject,
 } from './types.js';
@@ -166,6 +169,22 @@ export function review(props: Omit<ReviewSchema, '@type'>): WithContext<ReviewSc
 
 export function service(props: Omit<ServiceSchema, '@type'>): WithContext<ServiceSchema> {
   return withContext(clean({ '@type': 'Service', ...props }) as ServiceSchema);
+}
+
+export function brand(props: Omit<BrandSchema, '@type'>): WithContext<BrandSchema> {
+  return withContext(clean({ '@type': 'Brand', ...props }) as BrandSchema);
+}
+
+export function siteNavigationElement(
+  props: Omit<SiteNavigationElementSchema, '@type'>,
+): WithContext<SiteNavigationElementSchema> {
+  return withContext(
+    clean({ '@type': 'SiteNavigationElement', ...props }) as SiteNavigationElementSchema,
+  );
+}
+
+export function imageObject(props: Omit<ImageObject, '@type'>): WithContext<ImageObject> {
+  return withContext(clean({ '@type': 'ImageObject', ...props }) as ImageObject);
 }
 
 // --- Schema Graph Builder ---

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -42,6 +42,8 @@ export type {
   ItemListSchema,
   ListItem,
   ServiceSchema,
+  BrandSchema,
+  SiteNavigationElementSchema,
   SchemaObject,
   WithContext,
   SchemaGraph,
@@ -69,6 +71,9 @@ export {
   itemList,
   review,
   service,
+  brand,
+  siteNavigationElement,
+  imageObject,
   schemaGraph,
   toJsonLdString,
 } from './builders.js';

--- a/packages/schema/src/react.ts
+++ b/packages/schema/src/react.ts
@@ -8,6 +8,7 @@ import type {
   ProductSchema,
   LocalBusinessSchema,
   OrganizationSchema,
+  PersonSchema,
   EventSchema,
   RecipeSchema,
   HowToSchema,
@@ -16,8 +17,10 @@ import type {
   JobPostingSchema,
   SoftwareAppSchema,
   WebSiteSchema,
+  ItemListSchema,
   ReviewSchema,
   ServiceSchema,
+  BrandSchema,
   SchemaGraph,
   WithContext,
   JsonLdBase,
@@ -31,6 +34,7 @@ import {
   breadcrumbList,
   localBusiness,
   organization,
+  person,
   event,
   recipe,
   howTo,
@@ -39,8 +43,10 @@ import {
   jobPosting,
   softwareApp,
   webSite,
+  itemList,
   review,
   service,
+  brand,
 } from './builders.js';
 
 // --- Generic JsonLd Component ---
@@ -167,4 +173,16 @@ export function ReviewJsonLd(props: OmitType<ReviewSchema>) {
 
 export function ServiceJsonLd(props: OmitType<ServiceSchema>) {
   return createElement(JsonLd, { schema: service(props) });
+}
+
+export function PersonJsonLd(props: OmitType<PersonSchema>) {
+  return createElement(JsonLd, { schema: person(props) });
+}
+
+export function ItemListJsonLd(props: OmitType<ItemListSchema>) {
+  return createElement(JsonLd, { schema: itemList(props) });
+}
+
+export function BrandJsonLd(props: OmitType<BrandSchema>) {
+  return createElement(JsonLd, { schema: brand(props) });
 }

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -16,6 +16,10 @@ export interface ThingBase extends JsonLdBase {
   description?: string;
   image?: string | ImageObject | Array<string | ImageObject>;
   sameAs?: string | string[];
+  identifier?: string | { '@type': 'PropertyValue'; name: string; value: string };
+  alternateName?: string | string[];
+  mainEntity?: JsonLdBase | JsonLdBase[];
+  potentialAction?: JsonLdBase | JsonLdBase[];
 }
 
 export interface ImageObject extends JsonLdBase {
@@ -42,6 +46,11 @@ export interface OrganizationSchema extends ThingBase {
   address?: PostalAddress;
   foundingDate?: string;
   numberOfEmployees?: number;
+  areaServed?: string | string[];
+  foundingLocation?: PostalAddress | string;
+  knowsAbout?: string | string[];
+  legalName?: string;
+  parentOrganization?: OrganizationSchema;
 }
 
 export interface ContactPoint extends JsonLdBase {
@@ -332,9 +341,29 @@ export interface SoftwareAppSchema extends ThingBase {
   softwareVersion?: string;
 }
 
+export interface BrandSchema extends JsonLdBase {
+  '@type': 'Brand';
+  name: string;
+  logo?: string | ImageObject;
+  slogan?: string;
+  url?: string;
+  sameAs?: string | string[];
+}
+
+export interface SiteNavigationElementSchema extends ThingBase {
+  '@type': 'SiteNavigationElement';
+  url: string;
+}
+
 export interface WebSiteSchema extends ThingBase {
   '@type': 'WebSite';
   potentialAction?: SearchActionSchema;
+  author?: PersonSchema | OrganizationSchema;
+  publisher?: OrganizationSchema;
+  mainEntity?: SiteNavigationElementSchema | SiteNavigationElementSchema[];
+  inLanguage?: string;
+  dateCreated?: string;
+  dateModified?: string;
 }
 
 export interface SearchActionSchema extends JsonLdBase {
@@ -390,7 +419,9 @@ export type SchemaObject =
   | WebSiteSchema
   | ItemListSchema
   | ReviewSchema
-  | ServiceSchema;
+  | ServiceSchema
+  | BrandSchema
+  | SiteNavigationElementSchema;
 
 /** JSON-LD with context */
 export type WithContext<T extends JsonLdBase> = T & {

--- a/packages/schema/src/validation.ts
+++ b/packages/schema/src/validation.ts
@@ -16,10 +16,22 @@ export interface SchemaValidationResult {
 }
 
 /**
- * Validate a schema object against Google Rich Results requirements.
- * This checks required fields beyond basic Schema.org conformance.
+ * Validate one or more schema objects against Google Rich Results requirements.
+ * When an array is passed, each object is validated and all issues are merged.
  */
-export function validateSchema(schema: SchemaObject): SchemaValidationResult {
+export function validateSchema(schema: SchemaObject | SchemaObject[]): SchemaValidationResult {
+  if (Array.isArray(schema)) {
+    const allIssues: ValidationIssue[] = [];
+    for (const s of schema) {
+      const result = validateSchema(s);
+      allIssues.push(...result.issues);
+    }
+    return {
+      valid: allIssues.filter((i) => i.severity === 'error').length === 0,
+      issues: allIssues,
+    };
+  }
+
   const issues: ValidationIssue[] = [];
 
   const obj = schema as unknown as Record<string, unknown>;

--- a/packages/schema/tsup.config.ts
+++ b/packages/schema/tsup.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
   external: ['react', 'react-dom'],
 });

--- a/packages/search-console/tsup.config.ts
+++ b/packages/search-console/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
 });

--- a/packages/sitemap/README.md
+++ b/packages/sitemap/README.md
@@ -1,75 +1,90 @@
-# @power-seo/sitemap — XML Sitemap Generator for TypeScript — Streaming, Index Splitting & Image/Video/News Extensions
+# @power-seo/sitemap
 
 [![npm version](https://img.shields.io/npm/v/@power-seo/sitemap)](https://www.npmjs.com/package/@power-seo/sitemap)
 [![npm downloads](https://img.shields.io/npm/dm/@power-seo/sitemap)](https://www.npmjs.com/package/@power-seo/sitemap)
+[![Socket](https://socket.dev/api/badge/npm/package/@power-seo/sitemap)](https://socket.dev/npm/package/@power-seo/sitemap)
+[![npm provenance](https://img.shields.io/badge/npm-provenance-enabled-blue)](https://github.com/CyberCraftBD/power-seo/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
 [![tree-shakeable](https://img.shields.io/badge/tree--shakeable-yes-brightgreen)](https://bundlephobia.com/package/@power-seo/sitemap)
 
----
+XML sitemap generation for TypeScript — streaming output, automatic index splitting, image/video/news extensions, and URL validation — works in Next.js, Remix, Express, and edge runtimes with zero runtime dependencies.
 
-## Overview
+`@power-seo/sitemap` produces standards-compliant `<urlset>` and `<sitemapindex>` XML from typed URL arrays. Provide a hostname and URL list — get back a valid XML string ready to serve as `Content-Type: application/xml`. For large catalogs, stream chunks with constant memory usage or auto-split at the 50,000-URL spec limit with a generated index file. All five functions are independently importable and tree-shakeable.
 
-**@power-seo/sitemap** is a zero-dependency XML sitemap generator for TypeScript that helps you generate standards-compliant sitemaps with image, video, and news extensions — including streaming generation and automatic index splitting for large sites.
-
-**What it does**
-
-- ✅ **Generate XML sitemaps** — `generateSitemap()` produces spec-compliant `<urlset>` XML strings
-- ✅ **Stream large sitemaps** — `streamSitemap()` yields XML chunks with constant memory usage
-- ✅ **Split into multiple files** — `splitSitemap()` auto-chunks at the 50,000-URL limit
-- ✅ **Generate sitemap indexes** — `generateSitemapIndex()` creates `<sitemapindex>` files pointing to child sitemaps
-- ✅ **Validate URL entries** — `validateSitemapUrl()` checks against Google's sitemap spec requirements
-
-**What it is not**
-
-- ❌ **Not a sitemap crawler** — does not discover URLs by crawling your site
-- ❌ **Not a submission client** — use `@power-seo/search-console` to submit sitemaps to GSC
-
-**Recommended for**
-
-- **Next.js App Router sites**, **Remix apps**, **Express servers**, **static site generators**, and any Node.js/edge environment that generates sitemaps programmatically
+> **Zero runtime dependencies** — only `@power-seo/core` as a peer.
 
 ---
 
-## Why @power-seo/sitemap Matters
+## Why @power-seo/sitemap?
 
-**The problem**
-
-- **Sites with 50,000+ URLs** cannot fit in a single sitemap file — the spec mandates splitting
-- **Image and video sitemaps** require `<image:image>` and `<video:video>` namespace extensions that most generators don't support
-- **Memory spikes** during XML string concatenation cause crashes or timeouts on large e-commerce catalogs
-
-**Why developers care**
-
-- **SEO:** Well-structured sitemaps improve crawl coverage and ensure all pages are discovered
-- **Performance:** Streaming generation keeps memory usage constant for million-URL datasets
-- **Indexing:** Image sitemaps help Google discover and index product images for Google Images
+| | Without | With |
+|---|---|---|
+| Spec compliance | ❌ Hand-built XML, wrong namespaces | ✅ Correct `<urlset>` + namespace declarations |
+| Large sites | ❌ Single file breaks at 50,000 URLs | ✅ Auto-split + sitemap index generation |
+| Memory usage | ❌ String concat spikes on large catalogs | ✅ Synchronous generator yields chunks |
+| Image indexing | ❌ Product images undiscoverable | ✅ `<image:image>` extension per URL |
+| Video SEO | ❌ No structured video metadata | ✅ `<video:video>` extension with title, duration |
+| News sitemaps | ❌ Missing publication + date tags | ✅ `<news:news>` extension for Google News |
+| Hostname handling | ❌ Hardcode absolute URLs everywhere | ✅ Pass `hostname` once; use relative `loc` paths |
+| Validation | ❌ Silent bad data reaches Google | ✅ `validateSitemapUrl()` returns errors + warnings |
 
 ---
 
-## Key Features
+## Features
 
-- **Full sitemap spec support** — `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>`, and all optional elements
-- **Image sitemap extension** — `<image:image>` tags with `loc`, `caption`, `title`, `license`
-- **Video sitemap extension** — `<video:video>` tags with title, description, thumbnail, duration
+- **Full sitemap spec support** — `<loc>`, `<lastmod>`, `<changefreq>`, `<priority>`, all optional elements
+- **Hostname + relative paths** — pass `hostname` in config; `loc` can be a relative path like `/about`
+- **Image sitemap extension** — `<image:image>` tags with `loc`, `caption`, `title`, `geoLocation`, `license`
+- **Video sitemap extension** — `<video:video>` tags with title, description, thumbnail, duration, rating
 - **News sitemap extension** — `<news:news>` tags with publication name, language, date
-- **Streaming generation** — `streamSitemap()` returns `AsyncIterable<string>` — no memory spike on large lists
-- **Automatic index splitting** — `splitSitemap()` chunks at `MAX_URLS_PER_SITEMAP` (50,000)
+- **Streaming generation** — `streamSitemap()` is a synchronous generator yielding XML string chunks; no memory spike on large lists
+- **Automatic index splitting** — `splitSitemap()` chunks at `MAX_URLS_PER_SITEMAP` (50,000) and returns both sitemaps and the index XML
 - **Sitemap index generation** — `generateSitemapIndex()` creates a `<sitemapindex>` pointing to child sitemaps
 - **URL validation** — `validateSitemapUrl()` returns `{ valid, errors, warnings }` without throwing
-- **Constants exported** — `MAX_URLS_PER_SITEMAP` (50,000) and `MAX_SITEMAP_SIZE_BYTES` (50MB)
+- **Constants exported** — `MAX_URLS_PER_SITEMAP` (50,000) and `MAX_SITEMAP_SIZE_BYTES` (52,428,800)
 - **Framework-agnostic** — works in Next.js API routes, Remix loaders, Express, Fastify, and edge runtimes
 - **Full TypeScript support** — typed `SitemapURL`, `SitemapImage`, `SitemapVideo`, `SitemapNews`, `SitemapConfig`
 - **Zero runtime dependencies** — pure TypeScript, no external XML libraries
+- **Tree-shakeable** — import only the functions you use
 
 ---
 
-## Benefits of Using @power-seo/sitemap
+## Comparison
 
-- **Improved crawl coverage**: Well-structured sitemaps with `lastmod` help Googlebot prioritize fresh pages
-- **Better image indexing**: `<image:image>` extensions surface product images in Google Images
-- **Safer implementation**: `validateSitemapUrl()` catches out-of-range `priority` values and invalid dates before serving
-- **Faster delivery**: Zero-dependency streaming generation works in any runtime without configuration
+| Feature                        | @power-seo/sitemap | next-sitemap | sitemap (npm) | xmlbuilder2 |
+| ------------------------------ | :----------------: | :----------: | :-----------: | :---------: |
+| Image sitemap extension        | ✅                 | ✅           | ✅            | ❌          |
+| Video sitemap extension        | ✅                 | ❌           | ✅            | ❌          |
+| News sitemap extension         | ✅                 | ❌           | ✅            | ❌          |
+| Streaming generation           | ✅                 | ❌           | ❌            | ❌          |
+| Auto index splitting           | ✅                 | ✅           | ❌            | ❌          |
+| URL validation                 | ✅                 | ❌           | ❌            | ❌          |
+| Hostname + relative loc paths  | ✅                 | ❌           | ❌            | ❌          |
+| Zero runtime dependencies      | ✅                 | ❌           | ❌            | ❌          |
+| Edge runtime compatible        | ✅                 | ❌           | ❌            | ❌          |
+| TypeScript-first               | ✅                 | Partial      | ❌            | ❌          |
+| Tree-shakeable                 | ✅                 | ❌           | ❌            | ❌          |
+
+---
+
+## Installation
+
+```bash
+npm install @power-seo/sitemap
+```
+
+```bash
+yarn add @power-seo/sitemap
+```
+
+```bash
+pnpm add @power-seo/sitemap
+```
+
+```bash
+bun add @power-seo/sitemap
+```
 
 ---
 
@@ -79,200 +94,196 @@
 import { generateSitemap } from '@power-seo/sitemap';
 
 const xml = generateSitemap({
+  hostname: 'https://example.com',
   urls: [
-    { loc: 'https://example.com/', lastmod: '2026-01-01', changefreq: 'daily', priority: 1.0 },
-    { loc: 'https://example.com/about', changefreq: 'monthly', priority: 0.8 },
-    { loc: 'https://example.com/blog/post-1', lastmod: '2026-01-15', priority: 0.6 },
+    { loc: '/', lastmod: '2026-01-01', changefreq: 'daily', priority: 1.0 },
+    { loc: '/about', changefreq: 'monthly', priority: 0.8 },
+    { loc: '/blog/post-1', lastmod: '2026-01-15', priority: 0.6 },
   ],
 });
 
 // Returns valid XML string:
 // <?xml version="1.0" encoding="UTF-8"?>
-// <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">...
+// <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+//   <url><loc>https://example.com/</loc>...
 ```
 
-**What you should see**
-
-- A standards-compliant XML sitemap string ready to serve as `Content-Type: application/xml`
-- `<urlset>` containing `<url>` entries with the fields you provided
+`hostname` is required — it is prepended to any `loc` value that is a relative path. Absolute `loc` values (starting with `http`) are used as-is.
 
 ---
 
-## Installation
+## Usage
 
-```bash
-npm i @power-seo/sitemap
-# or
-yarn add @power-seo/sitemap
-# or
-pnpm add @power-seo/sitemap
-# or
-bun add @power-seo/sitemap
+### Generating a Sitemap
+
+`generateSitemap()` accepts a `SitemapConfig` with `hostname` and `urls` and returns a complete XML string.
+
+```ts
+import { generateSitemap } from '@power-seo/sitemap';
+
+const xml = generateSitemap({
+  hostname: 'https://example.com',
+  urls: [
+    { loc: '/', lastmod: '2026-01-01', changefreq: 'daily', priority: 1.0 },
+    { loc: '/products', changefreq: 'weekly', priority: 0.9 },
+    { loc: '/blog', changefreq: 'daily', priority: 0.8 },
+  ],
+});
+
+// Serve as application/xml
+res.setHeader('Content-Type', 'application/xml');
+res.send(xml);
 ```
 
----
+### Streaming a Large Sitemap
 
-## Framework Compatibility
+`streamSitemap()` is a synchronous generator. It yields XML string chunks one `<url>` at a time — keeping memory usage constant regardless of catalog size.
 
-**Supported**
+```ts
+import { streamSitemap } from '@power-seo/sitemap';
 
-- ✅ Next.js App Router — use in `app/sitemap.xml/route.ts` API route
-- ✅ Next.js Pages Router — use in `pages/api/sitemap.xml.ts`
-- ✅ Remix — use in resource routes
-- ✅ Node.js 18+ — pure TypeScript, no native bindings
-- ✅ Edge runtimes — no `fs`, no `path`, no Node.js-specific APIs (except `streamSitemap` which uses `AsyncIterable`)
-- ✅ Fastify / Express — serve the XML string as response body
+const urls = fetchAllProductUrls(); // Iterable<SitemapURL>
 
-**Environment notes**
-
-- **SSR/SSG:** Fully supported — generate at request time or at build time
-- **Edge runtime:** `generateSitemap()` and `generateSitemapIndex()` are edge-compatible; `streamSitemap()` requires Node.js streams if writing to disk
-- **Browser-only usage:** Not applicable — sitemap generation is a server-side concern
-
----
-
-## Use Cases
-
-- **Next.js SSG sites** — generate a full sitemap from your CMS at build time
-- **E-commerce catalogs** — product image sitemaps with `<image:image>` for every listing
-- **News publishers** — `<news:news>` extension for Google News sitemap submission
-- **Multi-locale sites** — separate sitemaps per locale with a unified sitemap index
-- **Programmatic SEO** — generate sitemaps for thousands of auto-generated pages
-- **Large sites** — automatic splitting at 50,000 URLs per file with index generation
-- **Video platforms** — `<video:video>` extension for YouTube-style video SEO
-
----
-
-## Example (Before / After)
-
-```text
-Before:
-- Hand-built XML strings: missing namespace declarations, wrong date formats
-- Single 80,000-URL sitemap: invalid per spec (max 50,000), Google truncates
-- No image sitemap: product images not discovered by Googlebot Images
-
-After (@power-seo/sitemap):
-- generateSitemap({ urls }) → spec-compliant XML with correct namespace
-- splitSitemap(allUrls) + generateSitemapIndex() → auto-split + index file
-- urls[i].images = [{ loc, caption }] → <image:image> tags for each product
+const stream = streamSitemap('https://example.com', urls);
+for (const chunk of stream) {
+  response.write(chunk);
+}
+response.end();
 ```
 
----
+### Splitting Large Sitemaps with an Index
 
-## Implementation Best Practices
+`splitSitemap()` chunks a config at the 50,000-URL spec limit and returns all individual sitemap XML strings plus a sitemap index XML string that references them.
 
-- **Always include `lastmod`** — Googlebot uses it to prioritize re-crawling updated pages
-- **Keep `priority` values realistic** — setting everything to 1.0 signals ignored priority; reserve 1.0 for the homepage
-- **Use `changefreq: 'never'` for permanent content** — signals Googlebot to skip re-crawling
-- **Set `sitemap.xml` URL in `robots.txt`** — `Sitemap: https://example.com/sitemap.xml` is required for discovery
-- **Submit to Google Search Console** after generating — use `@power-seo/search-console` `submitSitemap()`
+```ts
+import { splitSitemap } from '@power-seo/sitemap';
 
----
+const { index, sitemaps } = splitSitemap({
+  hostname: 'https://example.com',
+  urls: largeUrlArray, // more than 50,000 entries
+});
 
-## Architecture Overview
+// Write each sitemap file
+for (const { filename, xml } of sitemaps) {
+  fs.writeFileSync(`./public${filename}`, xml);
+}
 
-**Where it runs**
+// Write the index (default filenames: /sitemap-0.xml, /sitemap-1.xml, ...)
+fs.writeFileSync('./public/sitemap.xml', index);
+```
 
-- **Build-time**: Generate static `sitemap.xml` files during `next build` or Remix production builds
-- **Runtime**: Serve dynamically from an API route; regenerate on demand or on ISR revalidation
-- **CI/CD**: Validate sitemap URL entries as part of pull request checks
+Custom filename pattern:
 
-**Data flow**
+```ts
+const { index, sitemaps } = splitSitemap(
+  { hostname: 'https://example.com', urls: largeUrlArray },
+  '/sitemaps/part-{index}.xml', // default: '/sitemap-{index}.xml'
+);
+```
 
-1. **Input**: Array of `SitemapURL` objects with `loc`, `lastmod`, optional images/videos/news
-2. **Analysis**: Spec validation, namespace detection, XML serialization
-3. **Output**: Valid XML string or `AsyncIterable<string>` stream
-4. **Action**: Serve as `application/xml`, write to disk, or submit to GSC via `@power-seo/search-console`
+### Generating a Sitemap Index Manually
 
----
+Use `generateSitemapIndex()` when you maintain separate sitemaps per section or locale and want to combine them under a single index file.
 
-## Features Comparison with Popular Packages
+```ts
+import { generateSitemapIndex } from '@power-seo/sitemap';
 
-| Capability                | next-sitemap | sitemap (npm) | xmlbuilder2 | @power-seo/sitemap |
-| ------------------------- | -----------: | ------------: | ----------: | -----------------: |
-| Image sitemap extension   |           ✅ |            ✅ |          ❌ |                 ✅ |
-| Video sitemap extension   |           ❌ |            ✅ |          ❌ |                 ✅ |
-| News sitemap extension    |           ❌ |            ✅ |          ❌ |                 ✅ |
-| Streaming generation      |           ❌ |            ❌ |          ❌ |                 ✅ |
-| Auto index splitting      |           ✅ |            ❌ |          ❌ |                 ✅ |
-| URL validation            |           ❌ |            ❌ |          ❌ |                 ✅ |
-| Zero runtime dependencies |           ❌ |            ❌ |          ❌ |                 ✅ |
-| Edge runtime compatible   |           ❌ |            ❌ |          ❌ |                 ✅ |
+const indexXml = generateSitemapIndex({
+  sitemaps: [
+    { loc: 'https://example.com/sitemap-pages.xml', lastmod: '2026-01-01' },
+    { loc: 'https://example.com/sitemap-products.xml', lastmod: '2026-01-15' },
+    { loc: 'https://example.com/sitemap-blog.xml', lastmod: '2026-01-20' },
+  ],
+});
+```
 
----
+### Image Sitemaps
 
-## [@power-seo](https://www.npmjs.com/org/power-seo) Ecosystem
+Add `images` to any `SitemapURL` entry to emit `<image:image>` extension tags:
 
-All 17 packages are independently installable — use only what you need.
+```ts
+import { generateSitemap } from '@power-seo/sitemap';
 
-| Package                                                                                    | Install                             | Description                                                             |
-| ------------------------------------------------------------------------------------------ | ----------------------------------- | ----------------------------------------------------------------------- |
-| [`@power-seo/core`](https://www.npmjs.com/package/@power-seo/core)                         | `npm i @power-seo/core`             | Framework-agnostic utilities, types, validators, and constants          |
-| [`@power-seo/react`](https://www.npmjs.com/package/@power-seo/react)                       | `npm i @power-seo/react`            | React SEO components — meta, Open Graph, Twitter Card, breadcrumbs      |
-| [`@power-seo/meta`](https://www.npmjs.com/package/@power-seo/meta)                         | `npm i @power-seo/meta`             | SSR meta helpers for Next.js App Router, Remix v2, and generic SSR      |
-| [`@power-seo/schema`](https://www.npmjs.com/package/@power-seo/schema)                     | `npm i @power-seo/schema`           | Type-safe JSON-LD structured data — 20 builders + 18 React components   |
-| [`@power-seo/content-analysis`](https://www.npmjs.com/package/@power-seo/content-analysis) | `npm i @power-seo/content-analysis` | Yoast-style SEO content scoring engine with React components            |
-| [`@power-seo/readability`](https://www.npmjs.com/package/@power-seo/readability)           | `npm i @power-seo/readability`      | Readability scoring — Flesch-Kincaid, Gunning Fog, Coleman-Liau, ARI    |
-| [`@power-seo/preview`](https://www.npmjs.com/package/@power-seo/preview)                   | `npm i @power-seo/preview`          | SERP, Open Graph, and Twitter/X Card preview generators                 |
-| [`@power-seo/sitemap`](https://www.npmjs.com/package/@power-seo/sitemap)                   | `npm i @power-seo/sitemap`          | XML sitemap generation, streaming, index splitting, and validation      |
-| [`@power-seo/redirects`](https://www.npmjs.com/package/@power-seo/redirects)               | `npm i @power-seo/redirects`        | Redirect engine with Next.js, Remix, and Express adapters               |
-| [`@power-seo/links`](https://www.npmjs.com/package/@power-seo/links)                       | `npm i @power-seo/links`            | Link graph analysis — orphan detection, suggestions, equity scoring     |
-| [`@power-seo/audit`](https://www.npmjs.com/package/@power-seo/audit)                       | `npm i @power-seo/audit`            | Full SEO audit engine — meta, content, structure, performance rules     |
-| [`@power-seo/images`](https://www.npmjs.com/package/@power-seo/images)                     | `npm i @power-seo/images`           | Image SEO — alt text, lazy loading, format analysis, image sitemaps     |
-| [`@power-seo/ai`](https://www.npmjs.com/package/@power-seo/ai)                             | `npm i @power-seo/ai`               | LLM-agnostic AI prompt templates and parsers for SEO tasks              |
-| [`@power-seo/analytics`](https://www.npmjs.com/package/@power-seo/analytics)               | `npm i @power-seo/analytics`        | Merge GSC + audit data, trend analysis, ranking insights, dashboard     |
-| [`@power-seo/search-console`](https://www.npmjs.com/package/@power-seo/search-console)     | `npm i @power-seo/search-console`   | Google Search Console API — OAuth2, service account, URL inspection     |
-| [`@power-seo/integrations`](https://www.npmjs.com/package/@power-seo/integrations)         | `npm i @power-seo/integrations`     | Semrush and Ahrefs API clients with rate limiting and pagination        |
-| [`@power-seo/tracking`](https://www.npmjs.com/package/@power-seo/tracking)                 | `npm i @power-seo/tracking`         | GA4, Clarity, PostHog, Plausible, Fathom — scripts + consent management |
+const xml = generateSitemap({
+  hostname: 'https://example.com',
+  urls: [
+    {
+      loc: '/products/blue-sneaker',
+      lastmod: '2026-01-10',
+      images: [
+        {
+          loc: 'https://cdn.example.com/sneaker-blue.jpg',
+          caption: 'Blue sneaker — side view',
+          title: 'Blue Running Sneaker',
+        },
+        {
+          loc: 'https://cdn.example.com/sneaker-blue-top.jpg',
+          caption: 'Blue sneaker — top view',
+        },
+      ],
+    },
+  ],
+});
+```
 
-### Ecosystem vs alternatives
+### Validating URL Entries
 
-| Need               | Common approach        | @power-seo approach                                  |
-| ------------------ | ---------------------- | ---------------------------------------------------- |
-| Sitemap generation | `next-sitemap`         | `@power-seo/sitemap` — streaming, image, video, news |
-| Sitemap submission | Manual GSC UI          | `@power-seo/search-console` — `submitSitemap()`      |
-| Image SEO          | Manual `<image:image>` | `@power-seo/sitemap` + `@power-seo/images`           |
-| Structured data    | Manual JSON-LD         | `@power-seo/schema` — typed builders                 |
+`validateSitemapUrl()` checks a `SitemapURL` against the sitemap spec and returns structured errors and warnings — useful in CI or before serving.
 
----
+```ts
+import { validateSitemapUrl } from '@power-seo/sitemap';
 
-## Enterprise Integration
+const result = validateSitemapUrl({
+  loc: '/about',
+  priority: 1.5, // out of range
+  changefreq: 'daily',
+});
 
-**Multi-tenant SaaS**
+// result.valid   → false
+// result.errors  → ['priority must be between 0.0 and 1.0']
+// result.warnings → []
+```
 
-- **Per-tenant sitemaps**: Generate separate sitemaps per client domain; serve from tenant-aware API routes
-- **Sitemap index**: Use `generateSitemapIndex()` to aggregate tenant sitemaps into a root index
-- **Scheduled regeneration**: Rebuild sitemaps nightly as new content is published
+### Next.js App Router Route Handler
 
-**ERP / internal portals**
+```ts
+// app/sitemap.xml/route.ts
+import { generateSitemap } from '@power-seo/sitemap';
 
-- Generate sitemaps only for public-facing modules (knowledge base, product catalog)
-- Use `validateSitemapUrl()` to enforce URL format standards across generated entries
-- Pipe large catalogs through `streamSitemap()` to avoid memory limits in serverless environments
+export async function GET() {
+  const urls = await fetchUrlsFromCms();
 
-**Recommended integration pattern**
+  const xml = generateSitemap({
+    hostname: 'https://example.com',
+    urls,
+  });
 
-- Generate sitemaps in **CI** at build time for static content
-- Serve dynamically from **API routes** for frequently updated content
-- Submit new sitemaps to GSC via `@power-seo/search-console` after deployment
-- Monitor crawl coverage in Google Search Console
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/xml' },
+  });
+}
+```
 
----
+### Remix Resource Route
 
-## Scope and Limitations
+```ts
+// app/routes/sitemap[.xml].ts
+import { generateSitemap } from '@power-seo/sitemap';
+import type { LoaderFunctionArgs } from '@remix-run/node';
 
-**This package does**
+export async function loader({ request }: LoaderFunctionArgs) {
+  const urls = await fetchUrlsFromDb();
 
-- ✅ Generate spec-compliant XML sitemaps from URL arrays
-- ✅ Support image, video, and news sitemap extensions
-- ✅ Stream large sitemaps to avoid memory spikes
-- ✅ Split sitemaps and generate sitemap index files
+  const xml = generateSitemap({
+    hostname: 'https://example.com',
+    urls,
+  });
 
-**This package does not**
-
-- ❌ Crawl your site to discover URLs — you provide the URL list
-- ❌ Submit sitemaps to Google — use `@power-seo/search-console` for submission
-- ❌ Monitor sitemap status — use Google Search Console for crawl coverage reports
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/xml' },
+  });
+}
+```
 
 ---
 
@@ -284,37 +295,51 @@ All 17 packages are independently installable — use only what you need.
 function generateSitemap(config: SitemapConfig): string;
 ```
 
-| Prop   | Type           | Description          |
-| ------ | -------------- | -------------------- |
-| `urls` | `SitemapURL[]` | Array of URL entries |
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `hostname` | `string` | ✅ | Base URL prepended to relative `loc` paths (e.g. `'https://example.com'`) |
+| `urls` | `SitemapURL[]` | ✅ | Array of URL entries |
+| `maxUrlsPerSitemap` | `number` | — | Override the 50,000-URL chunk size (used by `splitSitemap`) |
+| `outputDir` | `string` | — | Optional output directory hint (informational; does not write files) |
 
-#### `SitemapURL`
-
-| Prop         | Type                                                                              | Default | Description                              |
-| ------------ | --------------------------------------------------------------------------------- | ------- | ---------------------------------------- |
-| `loc`        | `string`                                                                          | —       | **Required.** Absolute URL               |
-| `lastmod`    | `string`                                                                          | —       | Last modified (ISO 8601 or `YYYY-MM-DD`) |
-| `changefreq` | `'always' \| 'hourly' \| 'daily' \| 'weekly' \| 'monthly' \| 'yearly' \| 'never'` | —       | Change frequency                         |
-| `priority`   | `number`                                                                          | `0.5`   | Priority 0.0–1.0                         |
-| `images`     | `SitemapImage[]`                                                                  | —       | Image extension entries                  |
-| `videos`     | `SitemapVideo[]`                                                                  | —       | Video extension entries                  |
-| `news`       | `SitemapNews`                                                                     | —       | News extension entry                     |
-
-### `streamSitemap(config)`
+### `streamSitemap(hostname, urls)`
 
 ```ts
-function streamSitemap(config: SitemapConfig): AsyncIterable<string>;
+function streamSitemap(
+  hostname: string,
+  urls: Iterable<SitemapURL>,
+): Generator<string, void, undefined>;
 ```
 
-Returns an async iterable that yields XML chunks. Suitable for piping to a Node.js `Writable`.
+Synchronous generator. Yields XML string chunks — one for the XML declaration and opening tag, one per `<url>` block, and one for the closing tag. Does not buffer the full XML in memory.
 
-### `splitSitemap(urls, maxPerFile?)`
+| Param | Type | Description |
+| --- | --- | --- |
+| `hostname` | `string` | Base URL prepended to relative `loc` paths |
+| `urls` | `Iterable<SitemapURL>` | Any iterable of URL entries — arrays, generators, database cursors |
+
+### `splitSitemap(config, sitemapUrlPattern?)`
 
 ```ts
-function splitSitemap(urls: SitemapURL[], maxPerFile?: number): SitemapURL[][];
+function splitSitemap(
+  config: SitemapConfig,
+  sitemapUrlPattern?: string,
+): { index: string; sitemaps: Array<{ filename: string; xml: string }> };
 ```
 
-Splits `urls` into chunks of at most `maxPerFile` (default: `MAX_URLS_PER_SITEMAP` = 50,000).
+Splits a large URL set into multiple sitemap files and returns the index XML and all sitemap XMLs. The `sitemapUrlPattern` parameter controls generated filenames using `{index}` as a placeholder.
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| `config` | `SitemapConfig` | — | Same config as `generateSitemap()` |
+| `sitemapUrlPattern` | `string` | `'/sitemap-{index}.xml'` | Filename pattern for each split sitemap |
+
+**Return value:**
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `index` | `string` | Sitemap index XML (`<sitemapindex>`) referencing all split files |
+| `sitemaps` | `Array<{ filename: string; xml: string }>` | Each split sitemap with its filename and XML string |
 
 ### `generateSitemapIndex(config)`
 
@@ -322,9 +347,9 @@ Splits `urls` into chunks of at most `maxPerFile` (default: `MAX_URLS_PER_SITEMA
 function generateSitemapIndex(config: SitemapIndexConfig): string;
 ```
 
-| Prop       | Type                  | Description                                  |
-| ---------- | --------------------- | -------------------------------------------- |
-| `sitemaps` | `SitemapIndexEntry[]` | Array of `{ loc: string; lastmod?: string }` |
+| Prop | Type | Description |
+| --- | --- | --- |
+| `sitemaps` | `SitemapIndexEntry[]` | Array of `{ loc: string; lastmod?: string }` entries |
 
 ### `validateSitemapUrl(url)`
 
@@ -332,47 +357,121 @@ function generateSitemapIndex(config: SitemapIndexConfig): string;
 function validateSitemapUrl(url: SitemapURL): SitemapValidationResult;
 ```
 
-Returns `{ valid: boolean; errors: string[]; warnings: string[] }`.
+Returns `{ valid: boolean; errors: string[]; warnings: string[] }`. Never throws.
 
 ---
 
-## Contributing
+## Types
 
-- Issues: [github.com/cybercraftbd/power-seo/issues](https://github.com/cybercraftbd/power-seo/issues)
-- PRs: [github.com/cybercraftbd/power-seo/pulls](https://github.com/cybercraftbd/power-seo/pulls)
-- Development setup:
-  1. `pnpm i`
-  2. `pnpm build`
-  3. `pnpm test`
+| Type | Description |
+| --- | --- |
+| `SitemapConfig` | `{ hostname: string; urls: SitemapURL[]; maxUrlsPerSitemap?: number; outputDir?: string }` |
+| `SitemapURL` | Single URL entry — see field table below |
+| `SitemapImage` | `{ loc: string; caption?: string; geoLocation?: string; title?: string; license?: string }` |
+| `SitemapVideo` | Video extension entry with `thumbnailLoc`, `title`, `description`, and optional fields |
+| `SitemapNews` | `{ publication: { name: string; language: string }; publicationDate: string; title: string }` |
+| `SitemapIndexConfig` | `{ sitemaps: SitemapIndexEntry[] }` |
+| `SitemapIndexEntry` | `{ loc: string; lastmod?: string }` |
+| `SitemapValidationResult` | `{ valid: boolean; errors: string[]; warnings: string[] }` |
 
-**Release workflow**
+### `SitemapURL` Fields
 
-- `npm version patch|minor|major`
-- `npm publish --access public`
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `loc` | `string` | — | **Required.** URL path (e.g. `/about`) or absolute URL. Hostname is prepended to relative paths. |
+| `lastmod` | `string` | — | Last modified date — ISO 8601 or `YYYY-MM-DD` |
+| `changefreq` | `'always' \| 'hourly' \| 'daily' \| 'weekly' \| 'monthly' \| 'yearly' \| 'never'` | — | Suggested crawl frequency |
+| `priority` | `number` | (no tag emitted) | Priority 0.0–1.0. When omitted, no `<priority>` tag is written. |
+| `images` | `SitemapImage[]` | — | Image extension entries — emits `<image:image>` blocks |
+| `videos` | `SitemapVideo[]` | — | Video extension entries — emits `<video:video>` blocks |
+| `news` | `SitemapNews` | — | News extension entry — emits `<news:news>` block |
+
+### Constants
+
+| Constant | Value | Description |
+| --- | --- | --- |
+| `MAX_URLS_PER_SITEMAP` | `50_000` | Maximum URLs allowed per sitemap file (spec limit) |
+| `MAX_SITEMAP_SIZE_BYTES` | `52_428_800` | Maximum sitemap file size in bytes (50 MB = 50 × 1024 × 1024) |
 
 ---
 
-## About [CyberCraft Bangladesh](https://ccbd.dev)
+## Use Cases
 
-**[CyberCraft Bangladesh](https://ccbd.dev)** is a Bangladesh-based enterprise-grade software engineering company specializing in ERP system development, AI-powered SaaS and business applications, full-stack SEO services, custom website development, and scalable eCommerce platforms. We design and develop intelligent, automation-driven SaaS and enterprise solutions that help startups, SMEs, NGOs, educational institutes, and large organizations streamline operations, enhance digital visibility, and accelerate growth through modern cloud-native technologies.
-
-|                      |                                                                |
-| -------------------- | -------------------------------------------------------------- |
-| **Website**          | [ccbd.dev](https://ccbd.dev)                                   |
-| **GitHub**           | [github.com/cybercraftbd](https://github.com/cybercraftbd)     |
-| **npm Organization** | [npmjs.com/org/power-seo](https://www.npmjs.com/org/power-seo) |
-| **Email**            | [info@ccbd.dev](mailto:info@ccbd.dev)                          |
+- **Next.js App Router** — generate sitemaps in `app/sitemap.xml/route.ts` at request time or build time
+- **E-commerce catalogs** — product image sitemaps with `<image:image>` for every listing; keep Google Images up to date
+- **News publishers** — `<news:news>` extension for Google News sitemap submission
+- **Multi-locale sites** — separate sitemaps per locale with a unified sitemap index
+- **Programmatic SEO** — generate sitemaps for thousands of auto-generated pages with no memory overhead
+- **Large sites** — automatic splitting at 50,000 URLs per file with a generated index
+- **Video platforms** — `<video:video>` extension with title, description, and thumbnail for video SEO
+- **CI/CD pipelines** — validate URL entries with `validateSitemapUrl()` as part of pull request checks
 
 ---
 
-## License
+## Architecture Overview
 
-**MIT**
+- **Pure TypeScript** — no compiled binary, no native modules
+- **Zero runtime dependencies** — only `@power-seo/core` as a peer dependency
+- **Framework-agnostic** — works in any JavaScript environment that supports ES2020+
+- **SSR compatible** — safe to run in Next.js Server Components, Remix loaders, or Express handlers
+- **Edge runtime safe** — no `fs`, no `path`, no Node.js-specific APIs; runs in Cloudflare Workers, Vercel Edge, Deno
+- **Synchronous generator streaming** — `streamSitemap()` uses `function*` — no async overhead, no backpressure complexity
+- **Auto namespace detection** — `generateSitemap()` only adds `xmlns:image`, `xmlns:video`, `xmlns:news` declarations when the URL set actually uses those extensions
+- **Tree-shakeable** — `"sideEffects": false` with named exports per function
+- **Dual ESM + CJS** — ships both formats via tsup for any bundler or `require()` usage
+
+---
+
+## Supply Chain Security
+
+- No install scripts (`postinstall`, `preinstall`)
+- No runtime network access
+- No `eval` or dynamic code execution
+- npm provenance enabled — every release is signed via Sigstore through GitHub Actions
+- CI-signed builds — all releases published via verified `github.com/CyberCraftBD/power-seo` workflow
+- Safe for SSR, Edge, and server environments
+
+---
+
+## The [@power-seo](https://www.npmjs.com/org/power-seo) Ecosystem
+
+All 17 packages are independently installable — use only what you need.
+
+| Package | Install | Description |
+| --- | --- | --- |
+| [`@power-seo/core`](https://www.npmjs.com/package/@power-seo/core) | `npm i @power-seo/core` | Framework-agnostic utilities, types, validators, and constants |
+| [`@power-seo/react`](https://www.npmjs.com/package/@power-seo/react) | `npm i @power-seo/react` | React SEO components — meta, Open Graph, Twitter Card, breadcrumbs |
+| [`@power-seo/meta`](https://www.npmjs.com/package/@power-seo/meta) | `npm i @power-seo/meta` | SSR meta helpers for Next.js App Router, Remix v2, and generic SSR |
+| [`@power-seo/schema`](https://www.npmjs.com/package/@power-seo/schema) | `npm i @power-seo/schema` | Type-safe JSON-LD structured data — 20 builders + 18 React components |
+| [`@power-seo/content-analysis`](https://www.npmjs.com/package/@power-seo/content-analysis) | `npm i @power-seo/content-analysis` | Yoast-style SEO content scoring engine with React components |
+| [`@power-seo/readability`](https://www.npmjs.com/package/@power-seo/readability) | `npm i @power-seo/readability` | Readability scoring — Flesch-Kincaid, Gunning Fog, Coleman-Liau, ARI |
+| [`@power-seo/preview`](https://www.npmjs.com/package/@power-seo/preview) | `npm i @power-seo/preview` | SERP, Open Graph, and Twitter/X Card preview generators |
+| [`@power-seo/sitemap`](https://www.npmjs.com/package/@power-seo/sitemap) | `npm i @power-seo/sitemap` | XML sitemap generation, streaming, index splitting, and validation |
+| [`@power-seo/redirects`](https://www.npmjs.com/package/@power-seo/redirects) | `npm i @power-seo/redirects` | Redirect engine with Next.js, Remix, and Express adapters |
+| [`@power-seo/links`](https://www.npmjs.com/package/@power-seo/links) | `npm i @power-seo/links` | Link graph analysis — orphan detection, suggestions, equity scoring |
+| [`@power-seo/audit`](https://www.npmjs.com/package/@power-seo/audit) | `npm i @power-seo/audit` | Full SEO audit engine — meta, content, structure, performance rules |
+| [`@power-seo/images`](https://www.npmjs.com/package/@power-seo/images) | `npm i @power-seo/images` | Image SEO — alt text, lazy loading, format analysis, image sitemaps |
+| [`@power-seo/ai`](https://www.npmjs.com/package/@power-seo/ai) | `npm i @power-seo/ai` | LLM-agnostic AI prompt templates and parsers for SEO tasks |
+| [`@power-seo/analytics`](https://www.npmjs.com/package/@power-seo/analytics) | `npm i @power-seo/analytics` | Merge GSC + audit data, trend analysis, ranking insights, dashboard |
+| [`@power-seo/search-console`](https://www.npmjs.com/package/@power-seo/search-console) | `npm i @power-seo/search-console` | Google Search Console API — OAuth2, service account, URL inspection |
+| [`@power-seo/integrations`](https://www.npmjs.com/package/@power-seo/integrations) | `npm i @power-seo/integrations` | Semrush and Ahrefs API clients with rate limiting and pagination |
+| [`@power-seo/tracking`](https://www.npmjs.com/package/@power-seo/tracking) | `npm i @power-seo/tracking` | GA4, Clarity, PostHog, Plausible, Fathom — scripts + consent management |
 
 ---
 
 ## Keywords
 
-```text
-seo, sitemap, xml-sitemap, sitemap-generator, image-sitemap, video-sitemap, news-sitemap, sitemap-index, typescript, nextjs, remix, streaming, crawl-budget, google-indexing
-```
+xml sitemap generator typescript · sitemap npm package · nextjs sitemap · streaming sitemap · sitemap index generator · image sitemap extension · video sitemap extension · news sitemap google · split sitemap 50000 urls · sitemap validation · edge runtime sitemap · remix sitemap · programmatic seo sitemap · sitemap generator zero dependencies · typescript xml sitemap · sitemap url priority · crawl budget optimization · sitemap changelog · google sitemap spec · seo sitemap typescript
+
+---
+
+## About [CyberCraft Bangladesh](https://ccbd.dev)
+
+**[CyberCraft Bangladesh](https://ccbd.dev)** is a Bangladesh-based enterprise-grade software development and Full Stack SEO service provider company specializing in ERP system development, AI-powered SaaS and business applications, full-stack SEO services, custom website development, and scalable eCommerce platforms. We design and develop intelligent, automation-driven SaaS and enterprise solutions that help startups, SMEs, NGOs, educational institutes, and large organizations streamline operations, enhance digital visibility, and accelerate growth through modern cloud-native technologies.
+
+[![Website](https://img.shields.io/badge/Website-ccbd.dev-blue?style=for-the-badge)](https://ccbd.dev)
+[![GitHub](https://img.shields.io/badge/GitHub-cybercraftbd-black?style=for-the-badge&logo=github)](https://github.com/cybercraftbd)
+[![npm](https://img.shields.io/badge/npm-power--seo-red?style=for-the-badge&logo=npm)](https://www.npmjs.com/org/power-seo)
+[![Email](https://img.shields.io/badge/Email-info@ccbd.dev-green?style=for-the-badge&logo=gmail)](mailto:info@ccbd.dev)
+
+© 2026 [CyberCraft Bangladesh](https://ccbd.dev) · Released under the [MIT License](../../LICENSE)

--- a/packages/sitemap/src/types.ts
+++ b/packages/sitemap/src/types.ts
@@ -29,7 +29,7 @@ export interface SitemapValidationResult {
 }
 
 /** Maximum URLs allowed per sitemap file. */
-export const MAX_URLS_PER_SITEMAP = 50_000;
+export const MAX_URLS_PER_SITEMAP = 50_000 as const;
 
 /** Maximum sitemap file size in bytes (50MB). */
-export const MAX_SITEMAP_SIZE_BYTES = 50 * 1024 * 1024;
+export const MAX_SITEMAP_SIZE_BYTES = 52_428_800 as const;

--- a/packages/sitemap/tsup.config.ts
+++ b/packages/sitemap/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
 });

--- a/packages/tracking/tsup.config.ts
+++ b/packages/tracking/tsup.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  treeshake: true,
   external: ['react', 'react-dom'],
 });


### PR DESCRIPTION
## Summary

This PR resolves all 53 GitHub issues (#9 / #15–#74) that were open on the repository.

### Bug Fixes (Code)
- **#66** `TITLE_MIN_LENGTH` corrected 30 → 50 in `constants.ts`, README, and docs MDX
- **#34** `validateSchema()` return type corrected to `{ valid, issues: ValidationIssue[] }`
- **#40** `faqPage()` documented as plain array (not `{ questions: [...] }`)
- **#41** `breadcrumbList()` documented as plain array (not `{ items: [...] }`)
- **#42** `PersonJsonLd`, `ItemListJsonLd`, `BrandJsonLd` added to `@power-seo/schema/react`
- **#49** `MAX_SITEMAP_SIZE_BYTES` typed as literal (`as const`)
- **#58** `OrganizationSchema` expanded with `areaServed`, `foundingLocation`, `legalName`, `parentOrganization`
- **#59** `WebSiteSchema` expanded with `author` and `publisher`
- **#65** `WebSiteSchema` expanded with `mainEntity`
- **#72** `validateSchema()` now accepts `SchemaObject | SchemaObject[]`
- **#73** New builders: `brand()`, `siteNavigationElement()`, `imageObject()`
- **#74** `ThingBase` expanded with `identifier`, `alternateName`, `mainEntity`, `potentialAction`
- **#64** Removed `treeshake: true` from all 17 tsup configs — eliminates duplicate `sourceMappingURL` comments

### Documentation Fixes (README)
- **#32** `buildRobotsContent`/`parseRobotsContent` correctly attributed to `@power-seo/core` in react README
- **#35** Removed all `react-helmet-async`/`HelmetProvider` references from react README
- **#36–#39** Breadcrumb: `TwitterCardConfig`, `linkClassName`, `includeJsonLd`, separator `' / '` all fixed
- **#43** package.json description: "25+ schema types" → "23 schema builders"
- **#44** Component prop types: `*Config` → `Omit<*Schema, '@type' | '@context'>`
- **#45–#51** Sitemap README: `hostname` field, `splitSitemap()`, `streamSitemap()`, `MAX_SITEMAP_SIZE_BYTES`, priority note
- **#47, #52–#57** Preview README: `SerpPreviewData`, pixel limit 580px, `og.image.valid`, `truncated`, `siteTitle`
- **#60–#63** Content-analysis README: `focusKeyphrase`, `description`, `slug`, React subpath types
- **#26, #30, #31** Content-analysis: `AnalysisStatus` → `'ok'`, import fix, `disabledChecks` behavior
- **#15–#23** Core README: `buildTwitterTags`, `applyTitleTemplate`, `createTitleTemplate`, `META_DESCRIPTION_MAX_LENGTH`, `KEYWORD_DENSITY`, `calculateKeywordDensity`, `analyzeKeyphraseOccurrences`, `validateTitle`
- **#24–#29** Content-analysis README: `focusKeyphrase`, `slug`, `AnalysisStatus`, `overallStatus`, `softwareApp`, `description`
- **#67** CONTRIBUTING.md: removed broken GitHub Discussions reference
- **#68** Next.js App Router examples added to schema and sitemap READMEs
- **#70** `toJsonLdString()` featured in schema README examples

## Test plan
- [ ] Verify `TITLE_MIN_LENGTH = 50` in `packages/core/src/constants.ts`
- [ ] Verify `validateSchema()` accepts arrays in `packages/schema/src/validation.ts`
- [ ] Verify `brand()`, `siteNavigationElement()`, `imageObject()` exported from `@power-seo/schema`
- [ ] Verify `PersonJsonLd`, `ItemListJsonLd`, `BrandJsonLd` exported from `@power-seo/schema/react`
- [ ] Verify no duplicate `sourceMappingURL` in any `dist/*.js` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)