### PR TITLE
fix(security): replace remaining ReDoS regex patterns with string-based parsers

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,8 @@ export {
 // Text Statistics
 export {
   stripHtml,
+  extractFirstTagContent,
+  extractTagContents,
   getWords,
   getSentences,
   getParagraphs,


### PR DESCRIPTION
## Summary

Resolves the 5 remaining CodeQL security alerts after PR #89.

The previous fix used `(?:[^<]|<(?!\/tag>))*` alternation patterns which CodeQL still flags as polynomial. This PR replaces **every** HTML-parsing regex with provably linear string-based (indexOf/char-scanner) implementations.

### Changes

**`packages/core/src/text-stats.ts`**
- Added `removeHtmlTags()` — character-by-character scanner replaces `/<[^>]+>/g` (alert #14)
- Added `extractFirstTagContent(html, tag)` — finds first `<tag>...</tag>` using `indexOf`
- Added `extractTagContents(html, tag)` — finds all `<tag>...</tag>` using `indexOf`
- Both helpers exported from `@power-seo/core`

**`packages/core/src/keyword-density.ts`**
- Replaced `/<p[^>]*>...<\/p>/i` with `extractFirstTagContent(content, 'p')` (alert #15)
- Replaced `/<h1[^>]*>...<\/h1>/i` with `extractFirstTagContent(content, 'h1')` (alert #16)
- Replaced `/<h[2-6]...>/gi` exec loop with `extractTagContents()` per level (alert #17)

**`packages/content-analysis/src/checks/headings.ts`**
- Replaced `/<h([1-6])[^>]*>...<\/h\1>/gi` regex with a `while` loop using `indexOf` to find the earliest heading tag at each step (alert #6)

## Test plan
- [ ] `pnpm build` passes
- [ ] `pnpm test` passes
- [ ] CodeQL re-scan shows 0 open alerts