### PR TITLE
fix(audit): fix TS2352 cast error in structure rules

### DIFF
--- a/packages/audit/src/rules/structure.ts
+++ b/packages/audit/src/rules/structure.ts
@@ -14,9 +14,9 @@ export function runStructureRules(input: PageAuditInput): AuditRule[] {
   // synthesize a headings array so the H1 check below still fires correctly.
   if (
     !(input.headings && input.headings.length > 0) &&
-    typeof (input as Record<string, unknown>)['h1'] === 'string'
+    typeof (input as unknown as Record<string, unknown>)['h1'] === 'string'
   ) {
-    const h1Value = (input as Record<string, unknown>)['h1'] as string;
+    const h1Value = (input as unknown as Record<string, unknown>)['h1'] as string;
     input = { ...input, headings: [`h1:${h1Value}`] };
   }
 


### PR DESCRIPTION
## Summary
- Fixes `error TS2352` in `src/rules/structure.ts` lines 17 and 19
- The backward-compat shim that checks for a legacy `h1` field was casting `PageAuditInput` directly to `Record<string, unknown>`, which TypeScript rejects because neither type sufficiently overlaps
- Fix: cast through `unknown` first (`input as unknown as Record<string, unknown>`) which is the correct way to handle this intentional cross-type cast

## Test plan
- [ ] `pnpm run build` in `packages/audit` completes without TS errors
- [ ] DTS build succeeds in CI